### PR TITLE
Implement ShortMethodName rule with configurable minimum length and exceptions

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -27,6 +27,10 @@ parametersSchema:
             allow_in_foreach: bool(),
             allow_in_catch: bool(),
         ]),
+        short_method_name: structure([
+            minimum_length: int(),
+            exceptions: arrayOf(string()),
+        ]),
     ])
 
 # default parameters
@@ -53,6 +57,9 @@ parameters:
             allow_in_for_loops: false
             allow_in_foreach: false
             allow_in_catch: false
+        short_method_name:
+            minimum_length: 3
+            exceptions: []
 
 services:
     -
@@ -88,3 +95,8 @@ services:
             - %messed_up.short_variable.allow_in_for_loops%
             - %messed_up.short_variable.allow_in_foreach%
             - %messed_up.short_variable.allow_in_catch%
+    -
+        factory: Orrison\MessedUpPhpstan\Rules\ShortMethodName\Config
+        arguments:
+            - %messed_up.short_method_name.minimum_length%
+            - %messed_up.short_method_name.exceptions%

--- a/docs/ShortMethodName.md
+++ b/docs/ShortMethodName.md
@@ -1,0 +1,81 @@
+# ShortMethodName
+
+This rule enforces that method names must be of a minimum length.
+
+## Configuration
+
+```yaml
+parameters:
+    messed_up:
+        short_method_name:
+            minimum_length: 3
+            exceptions: []
+```
+
+### Options
+
+- `minimum_length` (int): The minimum length allowed for method names. Default: 3
+- `exceptions` (array): List of method names that should be allowed regardless of length. Default: []
+
+## Examples
+
+### ✗ Incorrect
+
+```php
+class Example
+{
+    public function a(): void // Error: 1 character
+    {
+    }
+
+    public function ab(): void // Error: 2 characters
+    {
+    }
+
+    public function x(): void // Error: 1 character
+    {
+    }
+}
+```
+
+### ✓ Correct
+
+```php
+class Example
+{
+    public function abc(): void // Valid: 3 characters
+    {
+    }
+
+    public function getName(): void // Valid: 7 characters
+    {
+    }
+}
+```
+
+### With Exceptions
+
+```yaml
+parameters:
+    messed_up:
+        short_method_name:
+            minimum_length: 3
+            exceptions: ['a', 'is']
+```
+
+```php
+class Example
+{
+    public function a(): void // Valid: in exceptions list
+    {
+    }
+
+    public function is(): void // Valid: in exceptions list
+    {
+    }
+
+    public function x(): void // Error: 1 character, not in exceptions
+    {
+    }
+}
+```

--- a/src/Rules/ShortMethodName/Config.php
+++ b/src/Rules/ShortMethodName/Config.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Orrison\MessedUpPhpstan\Rules\ShortMethodName;
+
+class Config
+{
+    public function __construct(
+        private int $minimumLength = 3,
+        /** @var string[] */
+        private array $exceptions = [],
+    ) {}
+
+    public function getMinimumLength(): int
+    {
+        return $this->minimumLength;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+}

--- a/src/Rules/ShortMethodName/ShortMethodNameRule.php
+++ b/src/Rules/ShortMethodName/ShortMethodNameRule.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Orrison\MessedUpPhpstan\Rules\ShortMethodName;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassMethod>
+ */
+final class ShortMethodNameRule implements Rule
+{
+    public function __construct(
+        private Config $config,
+    ) {}
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @return RuleError[] errors
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $messages = [];
+
+        $name = $node->name->name;
+
+        // Early return for exceptions
+        if (in_array($name, $this->config->getExceptions(), true)) {
+            return $messages;
+        }
+
+        // Check if method name is shorter than minimum length
+        if (strlen($name) < $this->config->getMinimumLength()) {
+            $messages[] = RuleErrorBuilder::message(sprintf('Method name "%s" is shorter than minimum length of %d characters.', $name, $this->config->getMinimumLength()))
+                ->identifier('MessedUpPhpstan.methodNameTooShort')
+                ->build();
+        }
+
+        return $messages;
+    }
+}

--- a/tests/Rules/ShortMethodName/DefaultOptionsTest.php
+++ b/tests/Rules/ShortMethodName/DefaultOptionsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortMethodName;
+
+use Orrison\MessedUpPhpstan\Rules\ShortMethodName\ShortMethodNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ShortMethodNameRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testExampleClass(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/ExampleClass.php',
+        ], [
+            ['Method name "a" is shorter than minimum length of 3 characters.', 9],
+            ['Method name "ab" is shorter than minimum length of 3 characters.', 12],
+            ['Method name "x" is shorter than minimum length of 3 characters.', 21],
+            ['Method name "is" is shorter than minimum length of 3 characters.', 24],
+            ['Method name "z" is shorter than minimum length of 3 characters.', 33],
+            ['Method name "cd" is shorter than minimum length of 3 characters.', 39],
+            ['Method name "b" is shorter than minimum length of 3 characters.', 45],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/config/default_options.neon',
+        ];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ShortMethodNameRule::class);
+    }
+}

--- a/tests/Rules/ShortMethodName/Fixture/ExampleClass.php
+++ b/tests/Rules/ShortMethodName/Fixture/ExampleClass.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortMethodName\Fixture;
+
+class ExampleClass
+{
+    public function a(): void // Error: 1 character
+    {}
+
+    public function ab(): void // Error: 2 characters
+    {}
+
+    public function abc(): void // Valid: 3 characters
+    {}
+
+    public function abcd(): void // Valid: 4+ characters
+    {}
+
+    public function x(): void // Error: 1 character
+    {}
+
+    public function is(): void // Error: 2 characters
+    {}
+
+    public function get(): void // Valid: 3 characters
+    {}
+
+    public function getName(): void // Valid: 7 characters
+    {}
+
+    public static function z(): void // Error: 1 character
+    {}
+
+    public static function xyz(): void // Valid: 3 characters
+    {}
+
+    protected function cd(): void // Error: 2 characters
+    {}
+
+    protected function efg(): void // Valid: 3 characters
+    {}
+
+    private function b(): void // Error: 1 character
+    {}
+}

--- a/tests/Rules/ShortMethodName/MinimumLength5Test.php
+++ b/tests/Rules/ShortMethodName/MinimumLength5Test.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortMethodName;
+
+use Orrison\MessedUpPhpstan\Rules\ShortMethodName\ShortMethodNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ShortMethodNameRule>
+ */
+class MinimumLength5Test extends RuleTestCase
+{
+    public function testExampleClass(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/ExampleClass.php',
+        ], [
+            ['Method name "a" is shorter than minimum length of 5 characters.', 9],
+            ['Method name "ab" is shorter than minimum length of 5 characters.', 12],
+            ['Method name "abc" is shorter than minimum length of 5 characters.', 15],
+            ['Method name "abcd" is shorter than minimum length of 5 characters.', 18],
+            ['Method name "x" is shorter than minimum length of 5 characters.', 21],
+            ['Method name "is" is shorter than minimum length of 5 characters.', 24],
+            ['Method name "get" is shorter than minimum length of 5 characters.', 27],
+            ['Method name "z" is shorter than minimum length of 5 characters.', 33],
+            ['Method name "xyz" is shorter than minimum length of 5 characters.', 36],
+            ['Method name "cd" is shorter than minimum length of 5 characters.', 39],
+            ['Method name "efg" is shorter than minimum length of 5 characters.', 42],
+            ['Method name "b" is shorter than minimum length of 5 characters.', 45],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/config/minimum_length_5.neon',
+        ];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ShortMethodNameRule::class);
+    }
+}

--- a/tests/Rules/ShortMethodName/WithExceptionsTest.php
+++ b/tests/Rules/ShortMethodName/WithExceptionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortMethodName;
+
+use Orrison\MessedUpPhpstan\Rules\ShortMethodName\ShortMethodNameRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ShortMethodNameRule>
+ */
+class WithExceptionsTest extends RuleTestCase
+{
+    public function testExampleClass(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/ExampleClass.php',
+        ], [
+            ['Method name "ab" is shorter than minimum length of 3 characters.', 12],
+            ['Method name "x" is shorter than minimum length of 3 characters.', 21],
+            ['Method name "z" is shorter than minimum length of 3 characters.', 33],
+            ['Method name "cd" is shorter than minimum length of 3 characters.', 39],
+            ['Method name "b" is shorter than minimum length of 3 characters.', 45],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/config/with_exceptions.neon',
+        ];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ShortMethodNameRule::class);
+    }
+}

--- a/tests/Rules/ShortMethodName/config/default_options.neon
+++ b/tests/Rules/ShortMethodName/config/default_options.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MessedUpPhpstan\Rules\ShortMethodName\ShortMethodNameRule
+
+parameters:
+    messed_up:
+        short_method_name:
+            minimum_length: 3
+            exceptions: []

--- a/tests/Rules/ShortMethodName/config/minimum_length_5.neon
+++ b/tests/Rules/ShortMethodName/config/minimum_length_5.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MessedUpPhpstan\Rules\ShortMethodName\ShortMethodNameRule
+
+parameters:
+    messed_up:
+        short_method_name:
+            minimum_length: 5
+            exceptions: []

--- a/tests/Rules/ShortMethodName/config/with_exceptions.neon
+++ b/tests/Rules/ShortMethodName/config/with_exceptions.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MessedUpPhpstan\Rules\ShortMethodName\ShortMethodNameRule
+
+parameters:
+    messed_up:
+        short_method_name:
+            minimum_length: 3
+            exceptions: ['a', 'is']


### PR DESCRIPTION
Adds the `ShortMethodName`, which enforces that class method names must meet a minimum length, with configuration to set the length and any exceptions.