### PR TITLE
New ConstantNamingConventionsRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Enforces that class property names should follow camelCase naming convention.
 
 Enforces that local variable names should follow camelCase naming convention.
 
+### [ConstantNamingConventions](docs/ConstantNamingConventions.md)
+
+Enforces that constant names should be in UPPERCASE.
+
 ### [PascalCase Class Name](docs/PascalCaseClassName.md)
 
 Enforces that class names should follow PascalCase naming convention.

--- a/docs/ConstantNamingConventions.md
+++ b/docs/ConstantNamingConventions.md
@@ -1,0 +1,68 @@
+# ConstantNamingConventions
+
+Enforces that constant names should be in UPPERCASE.
+
+This rule validates that all class constant names follow the uppercase naming convention, where all letters are uppercase and words are separated by underscores. This applies to constants in classes, interfaces, and enums.
+
+## Configuration
+
+This rule has no configuration options.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/messed-up-phpstan/config/extension.neon
+
+rules:
+    - Orrison\MessedUpPhpstan\Rules\ConstantNamingConventions\ConstantNamingConventionsRule
+```
+
+## Examples
+
+```php
+<?php
+
+class Example
+{
+    // Valid constant names
+    public const MAX_CONNECTIONS = 100; // ✓ Valid uppercase
+    public const DEFAULT_TIMEOUT = 30; // ✓ Valid uppercase  
+    public const API_VERSION = '1.0'; // ✓ Valid uppercase
+    private const INTERNAL_FLAG = true; // ✓ Valid uppercase
+    protected const BUFFER_SIZE = 1024; // ✓ Valid uppercase
+    
+    // Invalid constant names
+    public const maxConnections = 100; // ✗ Error: Constant name "maxConnections" is not in UPPERCASE.
+    public const Default_Timeout = 30; // ✗ Error: Constant name "Default_Timeout" is not in UPPERCASE.
+    public const api_version = '1.0'; // ✗ Error: Constant name "api_version" is not in UPPERCASE.
+    public const InternalFlag = true; // ✗ Error: Constant name "InternalFlag" is not in UPPERCASE.
+    public const bufferSize = 1024; // ✗ Error: Constant name "bufferSize" is not in UPPERCASE.
+}
+
+interface ApiInterface
+{
+    public const API_VERSION = '2.0'; // ✓ Valid uppercase
+    public const apiVersion = '2.0'; // ✗ Error: Constant name "apiVersion" is not in UPPERCASE.
+}
+
+enum Status
+{
+    case ACTIVE;
+    case INACTIVE;
+    
+    public const DEFAULT_STATUS = self::ACTIVE; // ✓ Valid uppercase
+    public const defaultStatus = self::ACTIVE; // ✗ Error: Constant name "defaultStatus" is not in UPPERCASE.
+}
+```
+
+## Important Notes
+
+- This rule applies to constants in classes, interfaces, and enums
+- Constants are checked regardless of their visibility (public, protected, private)
+- The rule enforces the traditional PHP constant naming convention where all letters must be uppercase
+- Underscores are allowed and encouraged for separating words in constant names
+- This rule only validates class/interface/enum constants, not global constants defined with `define()`
+- Enum cases are not validated by this rule, only enum constants

--- a/src/Rules/ConstantNamingConventions/ConstantNamingConventionsRule.php
+++ b/src/Rules/ConstantNamingConventions/ConstantNamingConventionsRule.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Orrison\MessedUpPhpstan\Rules\ConstantNamingConventions;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassConst;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassConst>
+ */
+final class ConstantNamingConventionsRule implements Rule
+{
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassConst::class;
+    }
+
+    /**
+     * @return RuleError[] errors
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $messages = [];
+
+        foreach ($node->consts as $const) {
+            $name = $const->name->name;
+
+            // Check if constant name is all uppercase
+            if ($name !== strtoupper($name)) {
+                $messages[] = RuleErrorBuilder::message(
+                    sprintf('Constant name "%s" is not in UPPERCASE.', $name)
+                )->identifier('MessedUpPhpstan.constantNamingConventions')
+                    ->build();
+            }
+        }
+
+        return $messages;
+    }
+}

--- a/tests/Rules/ConstantNamingConventions/DefaultOptionsTest.php
+++ b/tests/Rules/ConstantNamingConventions/DefaultOptionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Orrison\MessedUpPhpstan\Tests\Rules\ConstantNamingConventions;
+
+use Orrison\MessedUpPhpstan\Rules\ConstantNamingConventions\ConstantNamingConventionsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ConstantNamingConventionsRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testExampleClass(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/ExampleClass.php',
+        ], [
+            ['Constant name "maxConnections" is not in UPPERCASE.', 19],
+            ['Constant name "Default_Timeout" is not in UPPERCASE.', 21],
+            ['Constant name "api_version" is not in UPPERCASE.', 23],
+            ['Constant name "InternalFlag" is not in UPPERCASE.', 25],
+            ['Constant name "bufferSize" is not in UPPERCASE.', 27],
+            ['Constant name "MIXED_case" is not in UPPERCASE.', 29],
+            ['Constant name "lowercase" is not in UPPERCASE.', 31],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ConstantNamingConventionsRule::class);
+    }
+}

--- a/tests/Rules/ConstantNamingConventions/Fixture/ExampleClass.php
+++ b/tests/Rules/ConstantNamingConventions/Fixture/ExampleClass.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Orrison\MessedUpPhpstan\Tests\Rules\ConstantNamingConventions\Fixture;
+
+class ExampleClass
+{
+    // Valid constants (all uppercase)
+    public const MAX_CONNECTIONS = 100;
+
+    public const DEFAULT_TIMEOUT = 30;
+
+    public const API_VERSION = '1.0';
+
+    private const INTERNAL_FLAG = true;
+
+    protected const BUFFER_SIZE = 1024;
+
+    // Invalid constants (not all uppercase)
+    public const maxConnections = 100;
+
+    public const Default_Timeout = 30;
+
+    public const api_version = '1.0';
+
+    public const InternalFlag = true;
+
+    public const bufferSize = 1024;
+
+    public const MIXED_case = 'test';
+
+    public const lowercase = 'test';
+}

--- a/tests/Rules/ConstantNamingConventions/Fixture/InterfaceEnum.php
+++ b/tests/Rules/ConstantNamingConventions/Fixture/InterfaceEnum.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orrison\MessedUpPhpstan\Tests\Rules\ConstantNamingConventions\Fixture;
+
+interface ExampleInterface
+{
+    public const INTERFACE_CONSTANT = 'valid';
+
+    public const interfaceConstant = 'invalid';
+}
+
+enum ExampleEnum
+{
+    public const ENUM_CONSTANT = 'valid';
+
+    public const enumConstant = 'invalid';
+    case ValidCase;
+    case invalid_case;
+}

--- a/tests/Rules/ConstantNamingConventions/InterfaceEnumTest.php
+++ b/tests/Rules/ConstantNamingConventions/InterfaceEnumTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orrison\MessedUpPhpstan\Tests\Rules\ConstantNamingConventions;
+
+use Orrison\MessedUpPhpstan\Rules\ConstantNamingConventions\ConstantNamingConventionsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ConstantNamingConventionsRule>
+ */
+class InterfaceEnumTest extends RuleTestCase
+{
+    public function testInterfaceEnum(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/InterfaceEnum.php',
+        ], [
+            ['Constant name "interfaceConstant" is not in UPPERCASE.', 9],
+            ['Constant name "enumConstant" is not in UPPERCASE.', 16],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ConstantNamingConventionsRule::class);
+    }
+}

--- a/tests/Rules/ConstantNamingConventions/config/configured_rule.neon
+++ b/tests/Rules/ConstantNamingConventions/config/configured_rule.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MessedUpPhpstan\Rules\ConstantNamingConventions\ConstantNamingConventionsRule


### PR DESCRIPTION
Create a new rule for `ConstantNamingConventions` that enforces that constants must follow standard conventions of being all uppercase.