### PR TITLE
Remove Bad Code Style

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,6 +102,9 @@ Tests use exact line numbers from fixture files. When fixture formatting changes
 ### Namespace Convention
 All classes use `Orrison\MessedUpPhpstan\` prefix with rule-specific sub-namespaces.
 
+### Declare Strict Types
+Do NOT add `declare(strict_types=1);` to the top of files. This is not a requirement for this project and we do not want it. Unless the rule specifically has to do with this strict type declaration, then it is not needed. This is to keep the codebase consistent and avoid unnecessary complexity.
+
 ### Error Identifiers
 Use consistent identifiers for rule errors:
 ```php

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,8 +7,8 @@ Though many of the rules are focused on providing similar functionality to PHP M
 ## Architecture Pattern
 Each rule follows a 3-component structure:
 - `{RuleName}Rule.php` - The main rule implementing `Rule<NodeType>`
-- `Config.php` - Configuration class with boolean flags for rule options
-- Test files in `tests/Rules/{RuleName}/` with multiple configuration scenarios
+- `Config.php` - Configuration class with boolean flags for rule options. This class is used to define the configuration options for the rule. Not all rules have configuration options, but those that do will have a `Config` class this that do not will not.
+- Test files in `tests/Rules/{RuleName}/` with multiple configuration scenarios if applicable.
 - Unlike most other PHPStan extensions, this one does not use a single monolithic rule class. Each rule is its own class with its own config. And a User would enable/disable each rule individually in their PHPStan config. We do not register all rules for the user in our extension.neon.
 
 ### Key Files
@@ -30,6 +30,9 @@ composer test              # Run all tests with paratest
 composer format            # Auto-fix code style with PHP-CS-Fixer
 composer analyze           # Run PHPStan analysis
 ```
+
+### Running Final Checks
+Before finalizing changes, you need to ensure that formatting has been applied, static analysis is passing, and all tests are successful. It is important to run these checks in order. First check formatting, then static analysis, and finally run all tests. This is because formatting may change line numbers in tests, which can cause test failures if not done first.
 
 ## Configuration Architecture
 The extension uses Neon dependency injection with a hierarchical configuration system:
@@ -68,9 +71,6 @@ $pattern .= $this->config->getAllowConsecutiveUppercase()
 $pattern .= '$/';
 ```
 
-### Magic Method Exclusion
-Method rules exclude PHP magic methods via `$ignoredMethods` array check.
-
 ## Test Conventions
 
 ### Test Structure
@@ -92,6 +92,12 @@ Tests use exact line numbers from fixture files. When fixture formatting changes
 - **Config mismatch**: Verify test config file parameters match the rule being tested
 
 ## Project-Specific Patterns
+
+### Class Extensibility
+- No classes should be marked as `final` unless absolutely necessary. This allows for easier extension and customization in the future.
+- No methods or properties should be marked as `private` unless absolutely necessary. Use `protected` or `public` to allow for subclass overrides.
+    - Use `protected` for methods that are intended to be overridden in subclasses, and `public` for methods that are part of the public API of the rule.
+- It is okay to use `final` on classes or `private` on methods in tests if the intent is to prove that the rule works as expected in a specific scenario or if the rule is doing something specific with final classes and private methods/properties, but this should be avoided in the source code of our rules
 
 ### Namespace Convention
 All classes use `Orrison\MessedUpPhpstan\` prefix with rule-specific sub-namespaces.

--- a/src/Rules/CamelCaseMethodName/CamelCaseMethodNameRule.php
+++ b/src/Rules/CamelCaseMethodName/CamelCaseMethodNameRule.php
@@ -12,7 +12,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<ClassMethod>
  */
-final class CamelCaseMethodNameRule implements Rule
+class CamelCaseMethodNameRule implements Rule
 {
     /** @var array<string> */
     private array $ignoredMethods = [
@@ -37,7 +37,8 @@ final class CamelCaseMethodNameRule implements Rule
 
     public function __construct(
         private Config $config,
-    ) {}
+    ) {
+    }
 
     /**
      * @return class-string<Node>

--- a/src/Rules/CamelCaseMethodName/CamelCaseMethodNameRule.php
+++ b/src/Rules/CamelCaseMethodName/CamelCaseMethodNameRule.php
@@ -15,7 +15,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 class CamelCaseMethodNameRule implements Rule
 {
     /** @var array<string> */
-    private array $ignoredMethods = [
+    protected array $ignoredMethods = [
         '__construct',
         '__destruct',
         '__set',
@@ -36,7 +36,7 @@ class CamelCaseMethodNameRule implements Rule
     ];
 
     public function __construct(
-        private Config $config,
+        protected Config $config,
     ) {}
 
     /**

--- a/src/Rules/CamelCaseMethodName/CamelCaseMethodNameRule.php
+++ b/src/Rules/CamelCaseMethodName/CamelCaseMethodNameRule.php
@@ -37,8 +37,7 @@ class CamelCaseMethodNameRule implements Rule
 
     public function __construct(
         private Config $config,
-    ) {
-    }
+    ) {}
 
     /**
      * @return class-string<Node>

--- a/src/Rules/CamelCaseMethodName/Config.php
+++ b/src/Rules/CamelCaseMethodName/Config.php
@@ -5,9 +5,9 @@ namespace Orrison\MessedUpPhpstan\Rules\CamelCaseMethodName;
 class Config
 {
     public function __construct(
-        private bool $allowConsecutiveUppercase = false,
-        private bool $allowUnderscoreInTests = false,
-        private bool $allowUnderscorePrefix = false,
+        protected bool $allowConsecutiveUppercase = false,
+        protected bool $allowUnderscoreInTests = false,
+        protected bool $allowUnderscorePrefix = false,
     ) {}
 
     public function getAllowConsecutiveUppercase(): bool

--- a/src/Rules/CamelCaseParameterName/CamelCaseParameterNameRule.php
+++ b/src/Rules/CamelCaseParameterName/CamelCaseParameterNameRule.php
@@ -13,7 +13,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<Param>
  */
-final class CamelCaseParameterNameRule implements Rule
+class CamelCaseParameterNameRule implements Rule
 {
     protected string $pattern;
 

--- a/src/Rules/CamelCaseParameterName/Config.php
+++ b/src/Rules/CamelCaseParameterName/Config.php
@@ -5,8 +5,8 @@ namespace Orrison\MessedUpPhpstan\Rules\CamelCaseParameterName;
 class Config
 {
     public function __construct(
-        private bool $allowConsecutiveUppercase = false,
-        private bool $allowUnderscorePrefix = false,
+        protected bool $allowConsecutiveUppercase = false,
+        protected bool $allowUnderscorePrefix = false,
     ) {}
 
     public function getAllowConsecutiveUppercase(): bool

--- a/src/Rules/CamelCasePropertyName/CamelCasePropertyNameRule.php
+++ b/src/Rules/CamelCasePropertyName/CamelCasePropertyNameRule.php
@@ -12,7 +12,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<Property>
  */
-final class CamelCasePropertyNameRule implements Rule
+class CamelCasePropertyNameRule implements Rule
 {
     protected string $pattern;
 

--- a/src/Rules/CamelCasePropertyName/Config.php
+++ b/src/Rules/CamelCasePropertyName/Config.php
@@ -5,8 +5,8 @@ namespace Orrison\MessedUpPhpstan\Rules\CamelCasePropertyName;
 class Config
 {
     public function __construct(
-        private bool $allowConsecutiveUppercase = false,
-        private bool $allowUnderscorePrefix = false,
+        protected bool $allowConsecutiveUppercase = false,
+        protected bool $allowUnderscorePrefix = false,
     ) {}
 
     public function getAllowConsecutiveUppercase(): bool

--- a/src/Rules/CamelCaseVariableName/CamelCaseVariableNameRule.php
+++ b/src/Rules/CamelCaseVariableName/CamelCaseVariableNameRule.php
@@ -12,7 +12,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<Variable>
  */
-final class CamelCaseVariableNameRule implements Rule
+class CamelCaseVariableNameRule implements Rule
 {
     protected string $pattern;
 

--- a/src/Rules/CamelCaseVariableName/CamelCaseVariableNameRule.php
+++ b/src/Rules/CamelCaseVariableName/CamelCaseVariableNameRule.php
@@ -17,7 +17,7 @@ class CamelCaseVariableNameRule implements Rule
     protected string $pattern;
 
     /** @var string[] */
-    private array $ignoredVariables = [
+    protected array $ignoredVariables = [
         'php_errormsg',
         'http_response_header',
         'GLOBALS',

--- a/src/Rules/CamelCaseVariableName/Config.php
+++ b/src/Rules/CamelCaseVariableName/Config.php
@@ -5,8 +5,8 @@ namespace Orrison\MessedUpPhpstan\Rules\CamelCaseVariableName;
 class Config
 {
     public function __construct(
-        private bool $allowConsecutiveUppercase = false,
-        private bool $allowUnderscorePrefix = false,
+        protected bool $allowConsecutiveUppercase = false,
+        protected bool $allowUnderscorePrefix = false,
     ) {}
 
     public function getAllowConsecutiveUppercase(): bool

--- a/src/Rules/ConstantNamingConventions/ConstantNamingConventionsRule.php
+++ b/src/Rules/ConstantNamingConventions/ConstantNamingConventionsRule.php
@@ -12,7 +12,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<ClassConst>
  */
-final class ConstantNamingConventionsRule implements Rule
+class ConstantNamingConventionsRule implements Rule
 {
     /**
      * @return class-string<ClassConst>

--- a/src/Rules/PascalCaseClassName/Config.php
+++ b/src/Rules/PascalCaseClassName/Config.php
@@ -5,7 +5,7 @@ namespace Orrison\MessedUpPhpstan\Rules\PascalCaseClassName;
 class Config
 {
     public function __construct(
-        private bool $allowConsecutiveUppercase
+        protected bool $allowConsecutiveUppercase
     ) {}
 
     public function allowConsecutiveUppercase(): bool

--- a/src/Rules/PascalCaseClassName/PascalCaseClassNameRule.php
+++ b/src/Rules/PascalCaseClassName/PascalCaseClassNameRule.php
@@ -12,7 +12,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<Class_>
  */
-final class PascalCaseClassNameRule implements Rule
+class PascalCaseClassNameRule implements Rule
 {
     public function __construct(
         private Config $config,

--- a/src/Rules/PascalCaseClassName/PascalCaseClassNameRule.php
+++ b/src/Rules/PascalCaseClassName/PascalCaseClassNameRule.php
@@ -15,7 +15,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 class PascalCaseClassNameRule implements Rule
 {
     public function __construct(
-        private Config $config,
+        protected Config $config,
     ) {}
 
     /**

--- a/src/Rules/ShortMethodName/Config.php
+++ b/src/Rules/ShortMethodName/Config.php
@@ -5,9 +5,9 @@ namespace Orrison\MessedUpPhpstan\Rules\ShortMethodName;
 class Config
 {
     public function __construct(
-        private int $minimumLength = 3,
+        protected int $minimumLength = 3,
         /** @var string[] */
-        private array $exceptions = [],
+        protected array $exceptions = [],
     ) {}
 
     public function getMinimumLength(): int

--- a/src/Rules/ShortMethodName/ShortMethodNameRule.php
+++ b/src/Rules/ShortMethodName/ShortMethodNameRule.php
@@ -12,7 +12,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<ClassMethod>
  */
-final class ShortMethodNameRule implements Rule
+class ShortMethodNameRule implements Rule
 {
     public function __construct(
         private Config $config,

--- a/src/Rules/ShortMethodName/ShortMethodNameRule.php
+++ b/src/Rules/ShortMethodName/ShortMethodNameRule.php
@@ -15,7 +15,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 class ShortMethodNameRule implements Rule
 {
     public function __construct(
-        private Config $config,
+        protected Config $config,
     ) {}
 
     /**

--- a/src/Rules/ShortVariable/Config.php
+++ b/src/Rules/ShortVariable/Config.php
@@ -5,12 +5,12 @@ namespace Orrison\MessedUpPhpstan\Rules\ShortVariable;
 class Config
 {
     public function __construct(
-        private int $minimumLength = 3,
+        protected int $minimumLength = 3,
         /** @var string[] */
-        private array $exceptions = [],
-        private bool $allowInForLoops = false,
-        private bool $allowInForeach = false,
-        private bool $allowInCatch = false,
+        protected array $exceptions = [],
+        protected bool $allowInForLoops = false,
+        protected bool $allowInForeach = false,
+        protected bool $allowInCatch = false,
     ) {}
 
     public function getMinimumLength(): int

--- a/src/Rules/ShortVariable/ShortVariableRule.php
+++ b/src/Rules/ShortVariable/ShortVariableRule.php
@@ -27,7 +27,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<Node>
  */
-final class ShortVariableRule implements Rule
+class ShortVariableRule implements Rule
 {
     /** @var array<string, int> Track variables processed in special contexts by name and line */
     private array $specialContextVariables = [];

--- a/src/Rules/ShortVariable/ShortVariableRule.php
+++ b/src/Rules/ShortVariable/ShortVariableRule.php
@@ -30,22 +30,22 @@ use PHPStan\Rules\RuleErrorBuilder;
 class ShortVariableRule implements Rule
 {
     /** @var array<string, int> Track variables processed in special contexts by name and line */
-    private array $specialContextVariables = [];
+    protected array $specialContextVariables = [];
 
     /** @var string|null Track current file being processed */
-    private ?string $currentFile = null;
+    protected ?string $currentFile = null;
 
     /** @var array<string, int|string> Cached exceptions list as a set for O(1) lookups */
-    private array $exceptionsSet = [];
+    protected array $exceptionsSet = [];
 
     /** @var bool Cached config values */
-    private bool $allowInForLoops;
+    protected bool $allowInForLoops;
 
-    private bool $allowInForeach;
+    protected bool $allowInForeach;
 
-    private bool $allowInCatch;
+    protected bool $allowInCatch;
 
-    private int $minimumLength;
+    protected int $minimumLength;
 
     public function __construct(
         protected Config $config,
@@ -128,7 +128,7 @@ class ShortVariableRule implements Rule
      *
      * @return RuleError[]
      */
-    private function processAssignment(Assign $node): array
+    protected function processAssignment(Assign $node): array
     {
         // Only check the left side (the variable being assigned to)
         $var = $node->var;
@@ -151,7 +151,7 @@ class ShortVariableRule implements Rule
     /**
      * @return RuleError[]
      */
-    private function processForLoop(For_ $node): array
+    protected function processForLoop(For_ $node): array
     {
         $errors = [];
 
@@ -206,7 +206,7 @@ class ShortVariableRule implements Rule
     /**
      * @return RuleError[]
      */
-    private function processForeach(Foreach_ $node): array
+    protected function processForeach(Foreach_ $node): array
     {
         $errors = [];
 
@@ -250,7 +250,7 @@ class ShortVariableRule implements Rule
     /**
      * @return RuleError[]
      */
-    private function processCatch(Catch_ $node): array
+    protected function processCatch(Catch_ $node): array
     {
         $errors = [];
 
@@ -278,7 +278,7 @@ class ShortVariableRule implements Rule
     /**
      * @return RuleError[]
      */
-    private function processParameter(Param $node): array
+    protected function processParameter(Param $node): array
     {
         if (! $node->var instanceof Variable || ! is_string($node->var->name)) {
             return [];
@@ -306,7 +306,7 @@ class ShortVariableRule implements Rule
     /**
      * @return RuleError[]
      */
-    private function processProperty(Property $node): array
+    protected function processProperty(Property $node): array
     {
         $errors = [];
 
@@ -332,7 +332,7 @@ class ShortVariableRule implements Rule
     /**
      * @return RuleError[]
      */
-    private function checkVariableLength(Variable $node): array
+    protected function checkVariableLength(Variable $node): array
     {
         // Skip variables with non-string names (dynamic variables like $$var)
         if (! is_string($node->name)) {

--- a/src/Rules/Superglobals/SuperglobalsRule.php
+++ b/src/Rules/Superglobals/SuperglobalsRule.php
@@ -15,7 +15,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 class SuperglobalsRule implements Rule
 {
     /** @var string[] */
-    private array $superglobals = [
+    protected array $superglobals = [
         'GLOBALS',
         '_SERVER',
         '_GET',

--- a/src/Rules/Superglobals/SuperglobalsRule.php
+++ b/src/Rules/Superglobals/SuperglobalsRule.php
@@ -12,7 +12,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<Variable>
  */
-final class SuperglobalsRule implements Rule
+class SuperglobalsRule implements Rule
 {
     /** @var string[] */
     private array $superglobals = [

--- a/src/Rules/TraitConstantNamingConventions/TraitConstantNamingConventionsRule.php
+++ b/src/Rules/TraitConstantNamingConventions/TraitConstantNamingConventionsRule.php
@@ -13,7 +13,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<Trait_>
  */
-final class TraitConstantNamingConventionsRule implements Rule
+class TraitConstantNamingConventionsRule implements Rule
 {
     /**
      * @return class-string<Trait_>

--- a/tests/Rules/CamelCaseMethodName/AllOptionsTrueTest.php
+++ b/tests/Rules/CamelCaseMethodName/AllOptionsTrueTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseMethodName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseMethodName\CamelCaseMethodNameRule;

--- a/tests/Rules/CamelCaseMethodName/AllowConsecutiveUppercaseAndInTestsTest.php
+++ b/tests/Rules/CamelCaseMethodName/AllowConsecutiveUppercaseAndInTestsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseMethodName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseMethodName\CamelCaseMethodNameRule;

--- a/tests/Rules/CamelCaseMethodName/AllowConsecutiveUppercaseAndPrefixTest.php
+++ b/tests/Rules/CamelCaseMethodName/AllowConsecutiveUppercaseAndPrefixTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseMethodName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseMethodName\CamelCaseMethodNameRule;

--- a/tests/Rules/CamelCaseMethodName/AllowConsecutiveUppercaseOnlyTest.php
+++ b/tests/Rules/CamelCaseMethodName/AllowConsecutiveUppercaseOnlyTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseMethodName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseMethodName\CamelCaseMethodNameRule;

--- a/tests/Rules/CamelCaseMethodName/AllowUnderscoreInTestsAndPrefixTest.php
+++ b/tests/Rules/CamelCaseMethodName/AllowUnderscoreInTestsAndPrefixTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseMethodName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseMethodName\CamelCaseMethodNameRule;

--- a/tests/Rules/CamelCaseMethodName/AllowUnderscoreInTestsOnlyTest.php
+++ b/tests/Rules/CamelCaseMethodName/AllowUnderscoreInTestsOnlyTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseMethodName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseMethodName\CamelCaseMethodNameRule;

--- a/tests/Rules/CamelCaseMethodName/AllowUnderscorePrefixOnlyTest.php
+++ b/tests/Rules/CamelCaseMethodName/AllowUnderscorePrefixOnlyTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseMethodName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseMethodName\CamelCaseMethodNameRule;

--- a/tests/Rules/CamelCaseMethodName/DefaultOptionsTest.php
+++ b/tests/Rules/CamelCaseMethodName/DefaultOptionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseMethodName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseMethodName\CamelCaseMethodNameRule;

--- a/tests/Rules/CamelCaseParameterName/AllOptionsTrueTest.php
+++ b/tests/Rules/CamelCaseParameterName/AllOptionsTrueTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseParameterName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseParameterName\CamelCaseParameterNameRule;

--- a/tests/Rules/CamelCaseParameterName/AllowConsecutiveUppercaseTest.php
+++ b/tests/Rules/CamelCaseParameterName/AllowConsecutiveUppercaseTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseParameterName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseParameterName\CamelCaseParameterNameRule;

--- a/tests/Rules/CamelCaseParameterName/AllowUnderscorePrefixTest.php
+++ b/tests/Rules/CamelCaseParameterName/AllowUnderscorePrefixTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseParameterName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseParameterName\CamelCaseParameterNameRule;

--- a/tests/Rules/CamelCaseParameterName/DefaultOptionsTest.php
+++ b/tests/Rules/CamelCaseParameterName/DefaultOptionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseParameterName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseParameterName\CamelCaseParameterNameRule;

--- a/tests/Rules/CamelCasePropertyName/AllOptionsTrueTest.php
+++ b/tests/Rules/CamelCasePropertyName/AllOptionsTrueTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCasePropertyName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCasePropertyName\CamelCasePropertyNameRule;

--- a/tests/Rules/CamelCasePropertyName/AllowConsecutiveUppercaseTest.php
+++ b/tests/Rules/CamelCasePropertyName/AllowConsecutiveUppercaseTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCasePropertyName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCasePropertyName\CamelCasePropertyNameRule;

--- a/tests/Rules/CamelCasePropertyName/AllowUnderscorePrefixTest.php
+++ b/tests/Rules/CamelCasePropertyName/AllowUnderscorePrefixTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCasePropertyName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCasePropertyName\CamelCasePropertyNameRule;

--- a/tests/Rules/CamelCasePropertyName/DefaultOptionsTest.php
+++ b/tests/Rules/CamelCasePropertyName/DefaultOptionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCasePropertyName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCasePropertyName\CamelCasePropertyNameRule;

--- a/tests/Rules/CamelCaseVariableName/AllOptionsTrueTest.php
+++ b/tests/Rules/CamelCaseVariableName/AllOptionsTrueTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseVariableName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseVariableName\CamelCaseVariableNameRule;

--- a/tests/Rules/CamelCaseVariableName/AllowConsecutiveUppercaseTest.php
+++ b/tests/Rules/CamelCaseVariableName/AllowConsecutiveUppercaseTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseVariableName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseVariableName\CamelCaseVariableNameRule;

--- a/tests/Rules/CamelCaseVariableName/AllowUnderscorePrefixTest.php
+++ b/tests/Rules/CamelCaseVariableName/AllowUnderscorePrefixTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseVariableName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseVariableName\CamelCaseVariableNameRule;

--- a/tests/Rules/CamelCaseVariableName/DefaultOptionsTest.php
+++ b/tests/Rules/CamelCaseVariableName/DefaultOptionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\CamelCaseVariableName;
 
 use Orrison\MessedUpPhpstan\Rules\CamelCaseVariableName\CamelCaseVariableNameRule;

--- a/tests/Rules/ConstantNamingConventions/DefaultOptionsTest.php
+++ b/tests/Rules/ConstantNamingConventions/DefaultOptionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ConstantNamingConventions;
 
 use Orrison\MessedUpPhpstan\Rules\ConstantNamingConventions\ConstantNamingConventionsRule;

--- a/tests/Rules/ConstantNamingConventions/InterfaceEnumTest.php
+++ b/tests/Rules/ConstantNamingConventions/InterfaceEnumTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ConstantNamingConventions;
 
 use Orrison\MessedUpPhpstan\Rules\ConstantNamingConventions\ConstantNamingConventionsRule;

--- a/tests/Rules/ShortMethodName/DefaultOptionsTest.php
+++ b/tests/Rules/ShortMethodName/DefaultOptionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortMethodName;
 
 use Orrison\MessedUpPhpstan\Rules\ShortMethodName\ShortMethodNameRule;
@@ -18,13 +16,13 @@ class DefaultOptionsTest extends RuleTestCase
         $this->analyse([
             __DIR__ . '/Fixture/ExampleClass.php',
         ], [
-            ['Method name "a" is shorter than minimum length of 3 characters.', 9],
-            ['Method name "ab" is shorter than minimum length of 3 characters.', 12],
-            ['Method name "x" is shorter than minimum length of 3 characters.', 21],
-            ['Method name "is" is shorter than minimum length of 3 characters.', 24],
-            ['Method name "z" is shorter than minimum length of 3 characters.', 33],
-            ['Method name "cd" is shorter than minimum length of 3 characters.', 39],
-            ['Method name "b" is shorter than minimum length of 3 characters.', 45],
+            ['Method name "a" is shorter than minimum length of 3 characters.', 7],
+            ['Method name "ab" is shorter than minimum length of 3 characters.', 10],
+            ['Method name "x" is shorter than minimum length of 3 characters.', 19],
+            ['Method name "is" is shorter than minimum length of 3 characters.', 22],
+            ['Method name "z" is shorter than minimum length of 3 characters.', 31],
+            ['Method name "cd" is shorter than minimum length of 3 characters.', 37],
+            ['Method name "b" is shorter than minimum length of 3 characters.', 43],
         ]);
     }
 

--- a/tests/Rules/ShortMethodName/Fixture/ExampleClass.php
+++ b/tests/Rules/ShortMethodName/Fixture/ExampleClass.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortMethodName\Fixture;
 
 class ExampleClass

--- a/tests/Rules/ShortMethodName/MinimumLength5Test.php
+++ b/tests/Rules/ShortMethodName/MinimumLength5Test.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortMethodName;
 
 use Orrison\MessedUpPhpstan\Rules\ShortMethodName\ShortMethodNameRule;
@@ -18,18 +16,18 @@ class MinimumLength5Test extends RuleTestCase
         $this->analyse([
             __DIR__ . '/Fixture/ExampleClass.php',
         ], [
-            ['Method name "a" is shorter than minimum length of 5 characters.', 9],
-            ['Method name "ab" is shorter than minimum length of 5 characters.', 12],
-            ['Method name "abc" is shorter than minimum length of 5 characters.', 15],
-            ['Method name "abcd" is shorter than minimum length of 5 characters.', 18],
-            ['Method name "x" is shorter than minimum length of 5 characters.', 21],
-            ['Method name "is" is shorter than minimum length of 5 characters.', 24],
-            ['Method name "get" is shorter than minimum length of 5 characters.', 27],
-            ['Method name "z" is shorter than minimum length of 5 characters.', 33],
-            ['Method name "xyz" is shorter than minimum length of 5 characters.', 36],
-            ['Method name "cd" is shorter than minimum length of 5 characters.', 39],
-            ['Method name "efg" is shorter than minimum length of 5 characters.', 42],
-            ['Method name "b" is shorter than minimum length of 5 characters.', 45],
+            ['Method name "a" is shorter than minimum length of 5 characters.', 7],
+            ['Method name "ab" is shorter than minimum length of 5 characters.', 10],
+            ['Method name "abc" is shorter than minimum length of 5 characters.', 13],
+            ['Method name "abcd" is shorter than minimum length of 5 characters.', 16],
+            ['Method name "x" is shorter than minimum length of 5 characters.', 19],
+            ['Method name "is" is shorter than minimum length of 5 characters.', 22],
+            ['Method name "get" is shorter than minimum length of 5 characters.', 25],
+            ['Method name "z" is shorter than minimum length of 5 characters.', 31],
+            ['Method name "xyz" is shorter than minimum length of 5 characters.', 34],
+            ['Method name "cd" is shorter than minimum length of 5 characters.', 37],
+            ['Method name "efg" is shorter than minimum length of 5 characters.', 40],
+            ['Method name "b" is shorter than minimum length of 5 characters.', 43],
         ]);
     }
 

--- a/tests/Rules/ShortMethodName/WithExceptionsTest.php
+++ b/tests/Rules/ShortMethodName/WithExceptionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortMethodName;
 
 use Orrison\MessedUpPhpstan\Rules\ShortMethodName\ShortMethodNameRule;
@@ -18,11 +16,11 @@ class WithExceptionsTest extends RuleTestCase
         $this->analyse([
             __DIR__ . '/Fixture/ExampleClass.php',
         ], [
-            ['Method name "ab" is shorter than minimum length of 3 characters.', 12],
-            ['Method name "x" is shorter than minimum length of 3 characters.', 21],
-            ['Method name "z" is shorter than minimum length of 3 characters.', 33],
-            ['Method name "cd" is shorter than minimum length of 3 characters.', 39],
-            ['Method name "b" is shorter than minimum length of 3 characters.', 45],
+            ['Method name "ab" is shorter than minimum length of 3 characters.', 10],
+            ['Method name "x" is shorter than minimum length of 3 characters.', 19],
+            ['Method name "z" is shorter than minimum length of 3 characters.', 31],
+            ['Method name "cd" is shorter than minimum length of 3 characters.', 37],
+            ['Method name "b" is shorter than minimum length of 3 characters.', 43],
         ]);
     }
 

--- a/tests/Rules/ShortVariable/AllowCatchTest.php
+++ b/tests/Rules/ShortVariable/AllowCatchTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortVariable;
 
 use Orrison\MessedUpPhpstan\Rules\ShortVariable\ShortVariableRule;

--- a/tests/Rules/ShortVariable/AllowForLoopsTest.php
+++ b/tests/Rules/ShortVariable/AllowForLoopsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortVariable;
 
 use Orrison\MessedUpPhpstan\Rules\ShortVariable\ShortVariableRule;

--- a/tests/Rules/ShortVariable/AllowForeachTest.php
+++ b/tests/Rules/ShortVariable/AllowForeachTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortVariable;
 
 use Orrison\MessedUpPhpstan\Rules\ShortVariable\ShortVariableRule;

--- a/tests/Rules/ShortVariable/DefaultOptionsTest.php
+++ b/tests/Rules/ShortVariable/DefaultOptionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortVariable;
 
 use Orrison\MessedUpPhpstan\Rules\ShortVariable\ShortVariableRule;

--- a/tests/Rules/ShortVariable/MinimumLength5Test.php
+++ b/tests/Rules/ShortVariable/MinimumLength5Test.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortVariable;
 
 use Orrison\MessedUpPhpstan\Rules\ShortVariable\ShortVariableRule;

--- a/tests/Rules/ShortVariable/MultiFileStatePersistenceTest.php
+++ b/tests/Rules/ShortVariable/MultiFileStatePersistenceTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortVariable;
 
 use Orrison\MessedUpPhpstan\Rules\ShortVariable\ShortVariableRule;

--- a/tests/Rules/ShortVariable/MultipleProceduralFilesTest.php
+++ b/tests/Rules/ShortVariable/MultipleProceduralFilesTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortVariable;
 
 use Orrison\MessedUpPhpstan\Rules\ShortVariable\ShortVariableRule;

--- a/tests/Rules/ShortVariable/NonClassFileTest.php
+++ b/tests/Rules/ShortVariable/NonClassFileTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortVariable;
 
 use Orrison\MessedUpPhpstan\Rules\ShortVariable\ShortVariableRule;

--- a/tests/Rules/ShortVariable/PureProceduralFileTest.php
+++ b/tests/Rules/ShortVariable/PureProceduralFileTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortVariable;
 
 use Orrison\MessedUpPhpstan\Rules\ShortVariable\ShortVariableRule;

--- a/tests/Rules/ShortVariable/SameNameAfterContextTest.php
+++ b/tests/Rules/ShortVariable/SameNameAfterContextTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortVariable;
 
 use Orrison\MessedUpPhpstan\Rules\ShortVariable\ShortVariableRule;

--- a/tests/Rules/ShortVariable/WithExceptionsTest.php
+++ b/tests/Rules/ShortVariable/WithExceptionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\ShortVariable;
 
 use Orrison\MessedUpPhpstan\Rules\ShortVariable\ShortVariableRule;

--- a/tests/Rules/Superglobals/DefaultOptionsTest.php
+++ b/tests/Rules/Superglobals/DefaultOptionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\Superglobals;
 
 use Orrison\MessedUpPhpstan\Rules\Superglobals\SuperglobalsRule;

--- a/tests/Rules/TraitConstantNamingConventions/DefaultOptionsTest.php
+++ b/tests/Rules/TraitConstantNamingConventions/DefaultOptionsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace Orrison\MessedUpPhpstan\Tests\Rules\TraitConstantNamingConventions;
 
 use Orrison\MessedUpPhpstan\Rules\TraitConstantNamingConventions\TraitConstantNamingConventionsRule;


### PR DESCRIPTION
- Remove settings classes to `final`
- Remove setting methods or properties to `private`
- Remove declaring strict types