### PR TITLE
Add MissingClosureParameterTypehint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Enforces that local variable names should follow camelCase naming convention.
 
 Enforces that constant names should be in UPPERCASE.
 
+### [MissingClosureParameterTypehint](docs/MissingClosureParameterTypehint.md)
+
+Enforces that all parameters in anonymous functions (closures) have type declarations.
+
 ### [PascalCase Class Name](docs/PascalCaseClassName.md)
 
 Enforces that class names should follow PascalCase naming convention.

--- a/docs/MissingClosureParameterTypehint.md
+++ b/docs/MissingClosureParameterTypehint.md
@@ -1,0 +1,79 @@
+# MissingClosureParameterTypehint
+
+Enforces that all parameters in anonymous functions (closures) have type declarations.
+
+This rule ensures that anonymous functions maintain the same level of type safety as regular functions by requiring explicit type hints for all closure parameters. Type hints improve code readability, enable better IDE support, and help catch type-related errors during static analysis.
+
+## Configuration
+
+This rule has no configuration options.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/messed-up-phpstan/config/extension.neon
+
+rules:
+    - Orrison\MessedUpPhpstan\Rules\MissingClosureParameterTypehint\MissingClosureParameterTypehintRule
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class ExampleClass
+{
+    public function processData()
+    {
+        // ✓ Valid - closure with typed parameters
+        $validClosure = function (string $name, int $age): string {
+            return $name . ' is ' . $age . ' years old';
+        };
+
+        // ✗ Error: Parameter #1 $name of anonymous function has no typehint.
+        // ✗ Error: Parameter #2 $age of anonymous function has no typehint.
+        $invalidClosure = function ($name, $age) {
+            return $name . ' is ' . $age . ' years old';
+        };
+
+        // ✓ Valid - closure with no parameters
+        $noParamsClosure = function (): string {
+            return 'No parameters';
+        };
+
+        // ✓ Valid - using in array_map with typed parameter
+        $numbers = [1, 2, 3];
+        array_map(function (int $n): int {
+            return $n * 2;
+        }, $numbers);
+
+        // ✗ Error: Parameter #1 $n of anonymous function has no typehint.
+        array_map(function ($n) {
+            return $n * 2;
+        }, $numbers);
+
+        // ✓ Valid - closure with reference parameter that has type
+        $refClosure = function (string &$value): void {
+            $value = strtoupper($value);
+        };
+
+        // ✗ Error: Parameter #1 $value of anonymous function has no typehint.
+        $refUntypedClosure = function (&$value) {
+            $value = strtoupper($value);
+        };
+    }
+}
+```
+
+## Important Notes
+
+- This rule only applies to anonymous functions (closures), not regular function or method declarations
+- All parameters must have type hints; partial typing (some typed, some untyped) will still trigger errors for the untyped parameters
+- Reference parameters (`&$param`) must also include type hints
+- Closures with no parameters are always valid

--- a/src/Rules/MissingClosureParameterTypehint/MissingClosureParameterTypehintRule.php
+++ b/src/Rules/MissingClosureParameterTypehint/MissingClosureParameterTypehintRule.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Orrison\MessedUpPhpstan\Rules\MissingClosureParameterTypehint;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Closure>
+ */
+class MissingClosureParameterTypehintRule implements Rule
+{
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return Closure::class;
+    }
+
+    /**
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $messages = [];
+
+        foreach ($node->params as $index => $param) {
+            if (null !== $param->type || ! $param->var instanceof Variable || ! is_string($param->var->name)) {
+                continue;
+            }
+
+            $messages[] = RuleErrorBuilder::message(sprintf('Parameter #%d $%s of anonymous function has no typehint.', 1 + $index, $param->var->name))
+                ->identifier('MessedUpPhpstan.closureParameterMissingTypehint')
+                ->build();
+        }
+
+        return $messages;
+    }
+}

--- a/tests/Rules/MissingClosureParameterTypehint/Fixture/ExampleClass.php
+++ b/tests/Rules/MissingClosureParameterTypehint/Fixture/ExampleClass.php
@@ -1,0 +1,53 @@
+<?php
+
+class ExampleClass
+{
+    public function methodWithClosures()
+    {
+        // Valid - closure with typed parameters
+        $validClosure = function (string $name, int $age): string {
+            return $name . ' is ' . $age . ' years old';
+        };
+
+        // Invalid - closure with untyped parameters
+        $invalidClosure1 = function ($name, $age) {
+            return $name . ' is ' . $age . ' years old';
+        };
+
+        // Mixed - some typed, some untyped
+        $mixedClosure = function (string $name, $age, int $id) {
+            return $name . ' with ID ' . $id . ' is ' . $age . ' years old';
+        };
+
+        // Valid - closure with no parameters
+        $noParamsClosure = function (): string {
+            return 'No parameters';
+        };
+
+        // Invalid - multiple untyped parameters
+        $multipleUntyped = function ($first, $second, $third) {
+            return $first . $second . $third;
+        };
+
+        // Valid - using in array_map with typed parameter
+        $numbers = [1, 2, 3];
+        array_map(function (int $n): int {
+            return $n * 2;
+        }, $numbers);
+
+        // Invalid - array_map with untyped parameter
+        array_map(function ($n) {
+            return $n * 2;
+        }, $numbers);
+
+        // Valid - closure with reference parameter that has type
+        $refClosure = function (string &$value): void {
+            $value = strtoupper($value);
+        };
+
+        // Invalid - closure with reference parameter without type
+        $refUntypedClosure = function (&$value) {
+            $value = strtoupper($value);
+        };
+    }
+}

--- a/tests/Rules/MissingClosureParameterTypehint/MissingClosureParameterTypehintTest.php
+++ b/tests/Rules/MissingClosureParameterTypehint/MissingClosureParameterTypehintTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Orrison\MessedUpPhpstan\Tests\Rules\MissingClosureParameterTypehint;
+
+use Orrison\MessedUpPhpstan\Rules\MissingClosureParameterTypehint\MissingClosureParameterTypehintRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<MissingClosureParameterTypehintRule>
+ */
+class MissingClosureParameterTypehintTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ExampleClass.php'],
+            [
+                ['Parameter #1 $name of anonymous function has no typehint.', 13],
+                ['Parameter #2 $age of anonymous function has no typehint.', 13],
+                ['Parameter #2 $age of anonymous function has no typehint.', 18],
+                ['Parameter #1 $first of anonymous function has no typehint.', 28],
+                ['Parameter #2 $second of anonymous function has no typehint.', 28],
+                ['Parameter #3 $third of anonymous function has no typehint.', 28],
+                ['Parameter #1 $n of anonymous function has no typehint.', 39],
+                ['Parameter #1 $value of anonymous function has no typehint.', 49],
+            ]
+        );
+    }
+
+    protected function getRule(): Rule
+    {
+        return new MissingClosureParameterTypehintRule();
+    }
+}


### PR DESCRIPTION
This pull request introduces a new PHPStan rule, `MissingClosureParameterTypehint`, which enforces that all parameters in anonymous functions (closures) have explicit type declarations. The changes include the implementation of the rule, documentation, and corresponding tests.

### New Rule Implementation

* **Rule Implementation (`src/Rules/MissingClosureParameterTypehint/MissingClosureParameterTypehintRule.php`)**: Added the `MissingClosureParameterTypehintRule` class to check for missing type hints in closure parameters. It generates errors for untyped parameters, including reference parameters.

### Documentation

* **Documentation for the Rule (`docs/MissingClosureParameterTypehint.md`)**: Added detailed documentation for the new rule, including its purpose, configuration, usage, examples, and important notes.
* **Update to `README.md` (`README.md`)**: Added a reference to the new rule in the list of available rules.

### Testing

* **Test Fixtures (`tests/Rules/MissingClosureParameterTypehint/Fixture/ExampleClass.php`)**: Added a fixture file with various examples of valid and invalid closures to test the rule.
* **Unit Tests (`tests/Rules/MissingClosureParameterTypehint/MissingClosureParameterTypehintTest.php`)**: Added a test case to validate the rule's behavior, ensuring it correctly identifies untyped closure parameters and generates appropriate error messages.