### PR TITLE
Refactor ShortVariable rule documentation and tests to clarify exemptions for for loop initialization; remove redundant error messages.

### DIFF
--- a/docs/ShortVariable.md
+++ b/docs/ShortVariable.md
@@ -122,7 +122,7 @@ With this configuration, variables named `$i`, `$j`, `$k`, `$x`, `$y`, and `$e` 
 **Type:** `bool`  
 **Default:** `false`
 
-Allows short variable names in for loop initialization and increment expressions.
+Allows short variable names in for loop initialization expressions.
 
 **Example:**
 ```neon
@@ -213,7 +213,7 @@ This rule checks:
 
 You can exempt variables in specific contexts:
 
-- **`allow_in_for_loops: true`** - Exempts variables declared in `for ($i = 0; ...)` and increment expressions
+- **`allow_in_for_loops: true`** - Exempts variables declared in `for ($i = 0; ...)` initialization expressions
 - **`allow_in_foreach: true`** - Exempts key and value variables in `foreach ($items as $key => $value)`
 - **`allow_in_catch: true`** - Exempts exception variables in `catch (Exception $e)`
 

--- a/src/Rules/ShortVariable/ShortVariableRule.php
+++ b/src/Rules/ShortVariable/ShortVariableRule.php
@@ -4,10 +4,6 @@ namespace Orrison\MessedUpPhpstan\Rules\ShortVariable;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\PostDec;
-use PhpParser\Node\Expr\PostInc;
-use PhpParser\Node\Expr\PreDec;
-use PhpParser\Node\Expr\PreInc;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Catch_;
@@ -158,29 +154,6 @@ class ShortVariableRule implements Rule
         // Check variables defined in for loop init expressions
         foreach ($node->init as $expr) {
             if ($expr instanceof Assign) {
-                $var = $expr->var;
-
-                if ($var instanceof Variable && is_string($var->name)) {
-                    // Track this variable as processed in special context
-                    $trackingKey = $var->name . '_' . $var->getLine();
-                    $this->specialContextVariables[$trackingKey] = $var->getLine();
-
-                    // Only report errors if exemption is not enabled
-                    if (! $this->allowInForLoops) {
-                        $variableErrors = $this->checkVariableLength($var);
-
-                        foreach ($variableErrors as $error) {
-                            $errors[] = $error;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Check variables in for loop increment expressions
-        foreach ($node->loop as $expr) {
-            if ($expr instanceof PostInc || $expr instanceof PreInc ||
-                $expr instanceof PostDec || $expr instanceof PreDec) {
                 $var = $expr->var;
 
                 if ($var instanceof Variable && is_string($var->name)) {

--- a/tests/Rules/ShortVariable/AllowCatchTest.php
+++ b/tests/Rules/ShortVariable/AllowCatchTest.php
@@ -20,7 +20,6 @@ class AllowCatchTest extends RuleTestCase
             ['Parameter name "$a" is shorter than minimum length of 3 characters.', 11],
             ['Variable name "$b" is shorter than minimum length of 3 characters.', 13],
             ['Variable name "$i" is shorter than minimum length of 3 characters.', 15],
-            ['Variable name "$i" is shorter than minimum length of 3 characters.', 15],
             ['Variable name "$j" is shorter than minimum length of 3 characters.', 16],
             ['Variable name "$k" is shorter than minimum length of 3 characters.', 21],
             ['Variable name "$v" is shorter than minimum length of 3 characters.', 21],

--- a/tests/Rules/ShortVariable/AllowForeachTest.php
+++ b/tests/Rules/ShortVariable/AllowForeachTest.php
@@ -20,7 +20,6 @@ class AllowForeachTest extends RuleTestCase
             ['Parameter name "$a" is shorter than minimum length of 3 characters.', 11],
             ['Variable name "$b" is shorter than minimum length of 3 characters.', 13],
             ['Variable name "$i" is shorter than minimum length of 3 characters.', 15],
-            ['Variable name "$i" is shorter than minimum length of 3 characters.', 15],
             ['Variable name "$j" is shorter than minimum length of 3 characters.', 16],
             ['Variable name "$e" is shorter than minimum length of 3 characters.', 27],
         ]);

--- a/tests/Rules/ShortVariable/DefaultOptionsTest.php
+++ b/tests/Rules/ShortVariable/DefaultOptionsTest.php
@@ -23,7 +23,6 @@ class DefaultOptionsTest extends RuleTestCase
             ['Variable name "$b" is shorter than minimum length of 3 characters.', 17],
             ['Variable name "$cd" is shorter than minimum length of 3 characters.', 18],
             ['Variable name "$i" is shorter than minimum length of 3 characters.', 21],
-            ['Variable name "$i" is shorter than minimum length of 3 characters.', 21],
             ['Variable name "$j" is shorter than minimum length of 3 characters.', 22],
             ['Variable name "$k" is shorter than minimum length of 3 characters.', 27],
             ['Variable name "$v" is shorter than minimum length of 3 characters.', 27],

--- a/tests/Rules/ShortVariable/MinimumLength5Test.php
+++ b/tests/Rules/ShortVariable/MinimumLength5Test.php
@@ -23,7 +23,6 @@ class MinimumLength5Test extends RuleTestCase
             ['Variable name "$b" is shorter than minimum length of 5 characters.', 17],
             ['Variable name "$cd" is shorter than minimum length of 5 characters.', 18],
             ['Variable name "$i" is shorter than minimum length of 5 characters.', 21],
-            ['Variable name "$i" is shorter than minimum length of 5 characters.', 21],
             ['Variable name "$j" is shorter than minimum length of 5 characters.', 22],
             ['Variable name "$k" is shorter than minimum length of 5 characters.', 27],
             ['Variable name "$v" is shorter than minimum length of 5 characters.', 27],


### PR DESCRIPTION
This pull request refines the handling of short variable names in for loops by removing support for increment expressions, updates related documentation, and simplifies the associated code and tests. The changes aim to streamline the rule implementation and improve clarity.

### Documentation Updates:
* Updated `docs/ShortVariable.md` to clarify that short variable names are only allowed in for loop initialization expressions and not in increment expressions. [[1]](diffhunk://#diff-25f1012521e5798acdb40c5d74e05d24839a88830ccd688b5a826c4cbf93b31bL125-R125) [[2]](diffhunk://#diff-25f1012521e5798acdb40c5d74e05d24839a88830ccd688b5a826c4cbf93b31bL216-R216)

### Code Simplification:
* Removed handling of increment expressions (`PostInc`, `PreInc`, `PostDec`, `PreDec`) from the `processForLoop` method in `src/Rules/ShortVariable/ShortVariableRule.php`. This simplifies the logic by focusing solely on initialization expressions.
* Removed unused imports for increment-related node types in `src/Rules/ShortVariable/ShortVariableRule.php`.

### Test Adjustments:
* Removed duplicate test cases for variable `$i` in multiple test files (`AllowCatchTest.php`, `AllowForeachTest.php`, `DefaultOptionsTest.php`, `MinimumLength5Test.php`) to eliminate redundancy. [[1]](diffhunk://#diff-b9c6ff2a15f025c42d613b2dd6d24bd5a658532bb512e10b78446d781772fdd6L23) [[2]](diffhunk://#diff-09e304d176001065ec932d52c73cafffc45463a3d703e0e7e54e528f4ca45e65L23) [[3]](diffhunk://#diff-5fac86eaee77e4cce3cecb467f453cb1ab2ecfa78915579eb3cf48ea80273290L26) [[4]](diffhunk://#diff-dacdaaaf88205b275b6992b52c07aabb497cbb25c39a184263ecf0cb67d3a58fL26)