### PR TITLE
Finish all unused rules

### DIFF
--- a/.harper-dictionary.txt
+++ b/.harper-dictionary.txt
@@ -4,3 +4,4 @@ PHPStan
 PHPStan's
 cyclomatic
 goto
+inheritdoc

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ parameters:
 | **[ShortVariable](docs/ShortVariable.md)** | Enforces minimum variable name length | Variables |
 | **[ForbidPestPhpOnly](docs/ForbidPestPhpOnly.md)** | Prevents committed Pest tests from using the `only()` filter | Tests |
 | **[Superglobals](docs/Superglobals.md)** | Discourages use of PHP superglobals | Superglobal Usage |
+| **[UnusedFormalParameter](docs/UnusedFormalParameter.md)** | Detects function/method/closure parameters that are declared but never used | Function/method/closure parameters |
 | **[UnusedLocalVariable](docs/UnusedLocalVariable.md)** | Detects local variables assigned but never read inside a function/method/closure | Local Variables |
 
 ### Control Flow
@@ -119,6 +120,15 @@ parameters:
 | **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |
 | **[TooManyMethods](docs/TooManyMethods.md)** | Detects classes with too many methods | Classes, Interfaces, Traits, Enums |
+
+### Already Covered by PHPStan
+
+These PHPMD rules are intentionally not reimplemented because PHPStan already provides equivalent (or better) detection out of the box. The linked documentation explains how to enable and configure them.
+
+| PHPMD Rule | PHPStan Equivalent | Enable At |
+|------------|--------------------|-----------|
+| **[UnusedPrivateMethod](docs/UnusedPrivateMethod.md)** | `PHPStan\Rules\DeadCode\UnusedPrivateMethodRule` | Rule level 4 |
+| **[UnusedPrivateField](docs/UnusedPrivateField.md)** | `PHPStan\Rules\DeadCode\UnusedPrivatePropertyRule` | Rule level 4 |
 
 ## Configuration
 

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -77,6 +77,11 @@ parametersSchema:
             allow_unused_foreach_variables: bool(),
             exceptions: arrayOf(string()),
         ]),
+        unused_formal_parameter: structure([
+            allow_unused_with_inheritdoc: bool(),
+            allow_overriding_methods: bool(),
+            exceptions: arrayOf(string()),
+        ]),
     ])
 
 # default parameters
@@ -141,6 +146,10 @@ parameters:
             show_methods_complexity: true
         unused_local_variable:
             allow_unused_foreach_variables: false
+            exceptions: []
+        unused_formal_parameter:
+            allow_unused_with_inheritdoc: true
+            allow_overriding_methods: true
             exceptions: []
 
 services:
@@ -242,3 +251,9 @@ services:
         arguments:
             - %meliorstan.unused_local_variable.allow_unused_foreach_variables%
             - %meliorstan.unused_local_variable.exceptions%
+    -
+        factory: Orrison\MeliorStan\Rules\UnusedFormalParameter\Config
+        arguments:
+            - %meliorstan.unused_formal_parameter.allow_unused_with_inheritdoc%
+            - %meliorstan.unused_formal_parameter.allow_overriding_methods%
+            - %meliorstan.unused_formal_parameter.exceptions%

--- a/docs/UnusedFormalParameter.md
+++ b/docs/UnusedFormalParameter.md
@@ -1,0 +1,165 @@
+# UnusedFormalParameter
+
+Detects formal parameters declared on functions, methods, and closures that are never read inside the body.
+
+This rule mirrors PHPMD's `UnusedFormalParameter` rule. PHPStan's built-in dead-code detection covers unused private methods and properties but does not flag unused parameters, so this rule fills that gap. The rule analyzes each function-like (named functions, methods, closures, arrow functions) in isolation.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `allow_unused_with_inheritdoc`
+- **Type**: `bool`
+- **Default**: `true`
+- **Description**: When enabled, methods whose PHPDoc contains `@inheritdoc` (or `{@inheritdoc}`) are skipped. This is useful for child methods that must keep the parent's signature even when they ignore some parameters.
+
+### `allow_overriding_methods`
+- **Type**: `bool`
+- **Default**: `true`
+- **Description**: When enabled, methods that override a method declared on a parent class or implemented interface are skipped. The signature is fixed by the contract, so unused parameters are usually intentional.
+
+### `exceptions`
+- **Type**: `string[]`
+- **Default**: `[]`
+- **Description**: A list of parameter names (without the `$` prefix) that should never be reported as unused. Useful for conventional throwaway names.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\UnusedFormalParameter\UnusedFormalParameterRule
+
+parameters:
+    meliorstan:
+        unused_formal_parameter:
+            allow_unused_with_inheritdoc: true
+            allow_overriding_methods: true
+            exceptions: []
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class Example
+{
+    public function calculate(int $used, int $unused): int // ✗ Error: Avoid unused parameter "$unused".
+    {
+        return $used + 1;
+    }
+
+    public function viaCompact(int $a, int $b): array
+    {
+        return compact('a', 'b'); // ✓ Valid — compact() string args count as reads.
+    }
+
+    public function variadicLike(int $a, int $b, int $c): array
+    {
+        return func_get_args(); // ✓ Valid — func_get_args() suppresses reporting for the whole scope.
+    }
+
+    public function __construct(public int $x) // ✓ Valid — promoted constructor params become properties.
+    {
+    }
+
+    public function magic(string $name, mixed $value): void
+    {
+        // ✓ Valid — magic methods (__set, __call, etc.) are never reported.
+    }
+
+    public function withClosure(int $outer): \Closure
+    {
+        return function () use ($outer) { // ✓ Valid — closure use clause counts as a read.
+            return $outer + 1;
+        };
+    }
+}
+```
+
+### Configuration Examples
+
+#### Disallow `@inheritdoc` Suppression
+
+```neon
+parameters:
+    meliorstan:
+        unused_formal_parameter:
+            allow_unused_with_inheritdoc: false
+```
+
+```php
+<?php
+
+class Child extends Parent
+{
+    /**
+     * @inheritdoc
+     */
+    public function handle(int $value, string $name): void // ✗ Error: Avoid unused parameter "$name".
+    {
+        echo $value;
+    }
+}
+```
+
+#### Disallow Overriding Method Suppression
+
+```neon
+parameters:
+    meliorstan:
+        unused_formal_parameter:
+            allow_overriding_methods: false
+```
+
+```php
+<?php
+
+class Child extends Parent
+{
+    public function process(int $value, string $name): void // ✗ Error: Avoid unused parameter "$name".
+    {
+        echo $value;
+    }
+}
+```
+
+#### Exceptions List
+
+```neon
+parameters:
+    meliorstan:
+        unused_formal_parameter:
+            exceptions: ['unused']
+```
+
+```php
+<?php
+
+function example(int $used, int $unused): int
+{
+    // ✓ Now valid — "unused" is in the exceptions list.
+    return $used;
+}
+```
+
+## Important Notes
+
+- **Scope**: The rule operates per function-like (function, method, closure, arrow function). Nested function-likes are analyzed independently and do not share state with their enclosing scope.
+- **Abstract and interface methods**: Methods without a body (abstract methods, interface methods) are never reported.
+- **Magic methods**: PHP magic methods (`__construct`, `__call`, `__set`, `__get`, etc.) are always skipped because their parameter lists are fixed by PHP.
+- **Promoted constructor properties**: Constructor parameters with a visibility modifier (`public`, `protected`, `private`) become real object properties and are never reported.
+- **`func_get_args()` family**: When the body calls `func_get_args()`, `func_get_arg()`, or `func_num_args()`, no parameters are reported for that scope because they are accessed dynamically.
+- **`compact()`**: String literal arguments to `compact()` are recognized as reads of the corresponding parameters.
+- **Variable variables**: When the body contains a variable variable like `$$name` or `${$expr}`, no parameters are reported for that scope to avoid false positives.
+- **Closure `use` clauses**: A nested closure's `use ($outer)` clause counts as a read of the outer-scope parameter.
+- **Arrow functions**: Arrow functions auto-capture by value, so any outer parameter referenced inside the arrow body counts as a read.
+- **By-reference parameters**: `&$out` parameters are checked normally. If a function only writes to a by-reference parameter and never reads it, that is still reported. Use the `exceptions` list to opt out per-name if this is noisy.
+- **Variadic parameters**: Variadic parameters (`...$values`) are checked normally and reported if their bound array is never read.

--- a/docs/UnusedPrivateField.md
+++ b/docs/UnusedPrivateField.md
@@ -1,0 +1,70 @@
+# UnusedPrivateField
+
+Detects private properties that are declared on a class but never accessed from within that class.
+
+> **Status: Already provided by PHPStan core — no MeliorStan rule needed.**
+>
+> PHPStan ships `PHPStan\Rules\DeadCode\UnusedPrivatePropertyRule` out of the box. Its implementation is more granular than PHPMD's `UnusedPrivateField`: it distinguishes between *fully unused*, *write-only*, and *read-only* properties. MeliorStan therefore intentionally does **not** reimplement this PHPMD rule.
+
+## How to enable
+
+The rule is registered automatically once your PHPStan rule level is **4 or higher**:
+
+```neon
+parameters:
+    level: 4
+```
+
+No additional MeliorStan configuration is needed — there is no `Orrison\MeliorStan\Rules\UnusedPrivateField\...` rule to register.
+
+## What it detects
+
+PHPStan reports three distinct error variants for private properties:
+
+1. **Fully unused** — the property is neither read nor written anywhere in the class.
+2. **Never read (write-only)** — the property is assigned but its value is never used. Often a sign of a forgotten getter or genuinely dead state.
+3. **Never written (read-only)** — the property is read but never assigned. Often indicates a missing constructor parameter or setter — and may be a real bug.
+
+PHPStan recognizes property access via `$this->property`, `self::$property`, `static::$property`, and `ClassName::$property`.
+
+## Customizing
+
+### Marking properties as always-used via PHPDoc tags
+
+If you use a framework like Doctrine where property assignment happens via reflection (e.g. through `@ORM\Column`), you can configure PHPStan to treat properties annotated with specific PHPDoc tags as always-read or always-written:
+
+```neon
+parameters:
+    propertyAlwaysReadTags:
+        - phpstan-property-always-read
+        - ORM\Column
+    propertyAlwaysWrittenTags:
+        - phpstan-property-always-written
+        - ORM\Column
+```
+
+### Programmatic extension
+
+For more advanced cases, implement a `PHPStan\Rules\Properties\ReadWritePropertiesExtension`. Most popular framework PHPStan extensions (Doctrine, Symfony, Laravel) already register one for you — installing the official extension package is usually all that's needed.
+
+### Interaction with `checkUninitializedProperties`
+
+If you also enable:
+
+```neon
+parameters:
+    checkUninitializedProperties: true
+```
+
+PHPStan will additionally report typed properties that are never assigned in the constructor. This pairs well with `UnusedPrivatePropertyRule` because together they catch both "never written" (a likely bug) and "never initialized in constructor" (a definite bug).
+
+## PHPMD parity notes
+
+PHPStan's behavior is a strict superset of PHPMD's `UnusedPrivateField`:
+
+- PHPMD only reports the *fully unused* case. PHPStan additionally reports the more useful *write-only* and *read-only* variants.
+- PHPMD relies on `@SuppressWarnings` annotations; PHPStan uses extensions and PHPDoc tags so framework-managed properties are silenced project-wide instead of per-property.
+
+## Bonus: unused private constants
+
+PHPStan also ships `UnusedPrivateConstantRule` at level 4, which detects unused private class constants. No extra configuration required.

--- a/docs/UnusedPrivateMethod.md
+++ b/docs/UnusedPrivateMethod.md
@@ -1,0 +1,56 @@
+# UnusedPrivateMethod
+
+Detects private methods that are declared on a class but never called from within that class.
+
+> **Status: Already provided by PHPStan core — no MeliorStan rule needed.**
+>
+> PHPStan ships `PHPStan\Rules\DeadCode\UnusedPrivateMethodRule` out of the box. Because PHPStan's implementation is well-maintained, integrates with the rest of its type system, and is extensible by framework packages, MeliorStan intentionally does **not** reimplement this PHPMD rule.
+
+## How to enable
+
+The rule is registered automatically once your PHPStan rule level is **4 or higher**. In your `phpstan.neon`:
+
+```neon
+parameters:
+    level: 4
+```
+
+No additional MeliorStan configuration is needed — there is no `Orrison\MeliorStan\Rules\UnusedPrivateMethod\...` rule to register.
+
+## What it detects
+
+- Private instance methods that are never called from inside the declaring class.
+- Private static methods that are never called from inside the declaring class.
+
+PHPStan recognizes calls made via:
+- `$this->methodName()`
+- `self::methodName()`
+- `static::methodName()`
+- `ClassName::methodName()`
+- Array callables like `[$this, 'methodName']` or `[self::class, 'methodName']`
+
+## What it ignores
+
+- Constructors (`__construct`).
+- The `__clone` magic method.
+- Methods declared inside traits (the trait may be used by classes that call the method).
+- Methods marked as always-used by an `AlwaysUsedMethodExtensionProvider` extension. Frameworks (e.g. Symfony, Laravel) and library packages (e.g. PHPUnit) commonly ship such extensions so things like event listeners, controller actions, and test methods are not flagged.
+
+## Customizing for frameworks
+
+If a framework method is being incorrectly flagged as unused, the right fix is usually one of:
+
+1. Install the framework's official PHPStan extension package, which typically registers an `AlwaysUsedMethodExtensionProvider` for you.
+2. Implement your own `AlwaysUsedMethodExtensionProvider` — see [PHPStan's developing extensions documentation](https://phpstan.org/developing-extensions/always-used-class-methods).
+
+## PHPMD parity notes
+
+PHPStan's behavior is very close to PHPMD's `UnusedPrivateMethod`, with a few intentional differences:
+
+- PHPStan does **not** automatically skip methods whose name matches the class name. (Modern PHP code uses `__construct`, so this PHPMD-era exclusion is rarely useful.)
+- PHPStan integrates with framework extensions to suppress false positives, where PHPMD relies on `@SuppressWarnings` annotations.
+- PHPStan handles array-callable forms (`[$this, 'foo']`) more thoroughly than PHPMD.
+
+## Bonus: unused private constants
+
+PHPStan also ships `UnusedPrivateConstantRule` at level 4, which detects unused private class constants in the same spirit. No extra configuration required.

--- a/src/Rules/UnusedFormalParameter/Config.php
+++ b/src/Rules/UnusedFormalParameter/Config.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\UnusedFormalParameter;
+
+class Config
+{
+    public function __construct(
+        protected bool $allowUnusedWithInheritdoc = true,
+        protected bool $allowOverridingMethods = true,
+        /** @var string[] */
+        protected array $exceptions = [],
+    ) {}
+
+    public function getAllowUnusedWithInheritdoc(): bool
+    {
+        return $this->allowUnusedWithInheritdoc;
+    }
+
+    public function getAllowOverridingMethods(): bool
+    {
+        return $this->allowOverridingMethods;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+}

--- a/src/Rules/UnusedFormalParameter/UnusedFormalParameterRule.php
+++ b/src/Rules/UnusedFormalParameter/UnusedFormalParameterRule.php
@@ -1,0 +1,301 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\UnusedFormalParameter;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FunctionLike>
+ */
+class UnusedFormalParameterRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = 'Avoid unused parameter "$%s".';
+
+    /** @var array<string, true> */
+    protected static array $magicMethods = [
+        '__construct' => true,
+        '__destruct' => true,
+        '__call' => true,
+        '__callstatic' => true,
+        '__get' => true,
+        '__set' => true,
+        '__isset' => true,
+        '__unset' => true,
+        '__sleep' => true,
+        '__wakeup' => true,
+        '__serialize' => true,
+        '__unserialize' => true,
+        '__tostring' => true,
+        '__invoke' => true,
+        '__set_state' => true,
+        '__clone' => true,
+        '__debuginfo' => true,
+    ];
+
+    /** @var array<string, int|string> Cached exceptions list as a set for O(1) lookups */
+    protected array $exceptionsSet = [];
+
+    protected bool $allowUnusedWithInheritdoc;
+
+    protected bool $allowOverridingMethods;
+
+    public function __construct(
+        protected Config $config,
+    ) {
+        $this->allowUnusedWithInheritdoc = $this->config->getAllowUnusedWithInheritdoc();
+        $this->allowOverridingMethods = $this->config->getAllowOverridingMethods();
+        $this->exceptionsSet = array_flip($this->config->getExceptions());
+    }
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return FunctionLike::class;
+    }
+
+    /**
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // No body — abstract methods or interface methods.
+        $stmts = $node->getStmts();
+
+        if ($stmts === null && ! $node instanceof ArrowFunction) {
+            return [];
+        }
+
+        // Per-method skip conditions.
+        if ($node instanceof ClassMethod) {
+            $methodName = strtolower($node->name->name);
+
+            if (isset(self::$magicMethods[$methodName])) {
+                return [];
+            }
+
+            if ($this->allowUnusedWithInheritdoc && $this->hasInheritDoc($node)) {
+                return [];
+            }
+
+            if ($this->allowOverridingMethods && $this->isOverridingMethod($node, $scope)) {
+                return [];
+            }
+        }
+
+        // Collect param info first so we know which names to look for and which
+        // ones to skip outright (promoted, exceptions).
+        /** @var array<string, array{name: string, line: int}> $candidates */
+        $candidates = [];
+
+        foreach ($node->getParams() as $param) {
+            if (! $param->var instanceof Variable || ! is_string($param->var->name)) {
+                continue;
+            }
+
+            // Promoted constructor properties become real properties — never report.
+            if ($param->flags !== 0) {
+                continue;
+            }
+
+            $name = $param->var->name;
+
+            if (isset($this->exceptionsSet[$name])) {
+                continue;
+            }
+
+            $candidates[$name] = ['name' => $name, 'line' => $param->getLine()];
+        }
+
+        if ($candidates === []) {
+            return [];
+        }
+
+        /** @var array<string, true> $reads */
+        $reads = [];
+        $hasVariableVariable = false;
+        $usesFuncGetArgs = false;
+
+        if ($node instanceof ArrowFunction) {
+            // Arrow function body is its single expression.
+            $this->walk($node->expr, $reads, $hasVariableVariable, $usesFuncGetArgs);
+        } elseif ($stmts !== null) {
+            foreach ($stmts as $stmt) {
+                $this->walk($stmt, $reads, $hasVariableVariable, $usesFuncGetArgs);
+            }
+        }
+
+        if ($hasVariableVariable || $usesFuncGetArgs) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($candidates as $name => $info) {
+            if (isset($reads[$name])) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(self::ERROR_MESSAGE_TEMPLATE, $name)
+            )
+                ->identifier('MeliorStan.unusedFormalParameter')
+                ->line($info['line'])
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Recursively walk a node, recording variable reads and detecting bail-out conditions.
+     *
+     * @param array<string, true> $reads
+     */
+    protected function walk(Node $node, array &$reads, bool &$hasVariableVariable, bool &$usesFuncGetArgs): void
+    {
+        // Nested function/method declarations have their own independent scope.
+        if ($node instanceof Function_ || $node instanceof ClassMethod) {
+            return;
+        }
+
+        if ($node instanceof Closure) {
+            // Variables imported via `use (...)` are reads in the outer scope.
+            foreach ($node->uses as $use) {
+                if (is_string($use->var->name)) {
+                    $reads[$use->var->name] = true;
+                }
+            }
+
+            // Closure body has its own scope — do not descend.
+            return;
+        }
+
+        if ($node instanceof ArrowFunction) {
+            // Arrow functions auto-capture by value — any variable referenced
+            // inside is a read of an outer-scope variable.
+            $this->walk($node->expr, $reads, $hasVariableVariable, $usesFuncGetArgs);
+
+            return;
+        }
+
+        if ($node instanceof FuncCall) {
+            if ($this->isFuncGetArgsCall($node)) {
+                $usesFuncGetArgs = true;
+            }
+
+            if ($this->isCompactCall($node)) {
+                foreach ($node->args as $arg) {
+                    if ($arg instanceof Arg && $arg->value instanceof String_) {
+                        $reads[$arg->value->value] = true;
+
+                        continue;
+                    }
+
+                    $this->walk($arg, $reads, $hasVariableVariable, $usesFuncGetArgs);
+                }
+
+                return;
+            }
+        }
+
+        if ($node instanceof Variable) {
+            if (! is_string($node->name)) {
+                $hasVariableVariable = true;
+                $this->walk($node->name, $reads, $hasVariableVariable, $usesFuncGetArgs);
+
+                return;
+            }
+
+            $reads[$node->name] = true;
+
+            return;
+        }
+
+        // Generic descent into child nodes.
+        foreach ($node->getSubNodeNames() as $subNodeName) {
+            $sub = $node->{$subNodeName};
+
+            if ($sub instanceof Node) {
+                $this->walk($sub, $reads, $hasVariableVariable, $usesFuncGetArgs);
+            } elseif (is_array($sub)) {
+                foreach ($sub as $item) {
+                    if ($item instanceof Node) {
+                        $this->walk($item, $reads, $hasVariableVariable, $usesFuncGetArgs);
+                    }
+                }
+            }
+        }
+    }
+
+    protected function isCompactCall(FuncCall $node): bool
+    {
+        if (! $node->name instanceof Name) {
+            return false;
+        }
+
+        return strtolower($node->name->getLast()) === 'compact';
+    }
+
+    protected function isFuncGetArgsCall(FuncCall $node): bool
+    {
+        if (! $node->name instanceof Name) {
+            return false;
+        }
+
+        $name = strtolower($node->name->getLast());
+
+        return $name === 'func_get_args' || $name === 'func_get_arg' || $name === 'func_num_args';
+    }
+
+    protected function hasInheritDoc(ClassMethod $node): bool
+    {
+        $doc = $node->getDocComment();
+
+        if ($doc === null) {
+            return false;
+        }
+
+        return stripos($doc->getText(), '@inheritdoc') !== false;
+    }
+
+    protected function isOverridingMethod(ClassMethod $node, Scope $scope): bool
+    {
+        $classRef = $scope->getClassReflection();
+
+        if ($classRef === null) {
+            return false;
+        }
+
+        $methodName = $node->name->name;
+
+        foreach ($classRef->getParents() as $parent) {
+            if ($parent->hasMethod($methodName)) {
+                return true;
+            }
+        }
+
+        foreach ($classRef->getInterfaces() as $interface) {
+            if ($interface->hasMethod($methodName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/DefaultOptionsTest.php
+++ b/tests/Rules/UnusedFormalParameter/DefaultOptionsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter;
+
+use Orrison\MeliorStan\Rules\UnusedFormalParameter\UnusedFormalParameterRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<UnusedFormalParameterRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testBasicUnused(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/BasicUnused.php'], [
+            [sprintf(UnusedFormalParameterRule::ERROR_MESSAGE_TEMPLATE, 'unused'), 7],
+            [sprintf(UnusedFormalParameterRule::ERROR_MESSAGE_TEMPLATE, 'unused'), 13],
+        ]);
+    }
+
+    public function testMagicMethods(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/MagicMethods.php'], []);
+    }
+
+    public function testAbstractMethod(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/AbstractMethod.php'], []);
+    }
+
+    public function testInterfaceMethod(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/InterfaceMethod.php'], []);
+    }
+
+    public function testInheritDocAllowedByDefault(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/InheritDocParent.php',
+                __DIR__ . '/Fixture/InheritDocChild.php',
+            ],
+            [],
+        );
+    }
+
+    public function testOverridingMethodAllowedByDefault(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/OverridingParent.php',
+                __DIR__ . '/Fixture/OverridingChild.php',
+            ],
+            [],
+        );
+    }
+
+    public function testFuncGetArgsSuppresses(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/FuncGetArgs.php'], []);
+    }
+
+    public function testCompactParam(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/CompactParam.php'], []);
+    }
+
+    public function testPromotedConstructor(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/PromotedConstructor.php'], []);
+    }
+
+    public function testVariableVariableSuppresses(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/VariableVariable.php'], []);
+    }
+
+    public function testClosureUseInside(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ClosureUseInside.php'], []);
+    }
+
+    public function testArrowFunctionUses(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ArrowFunctionUses.php'], []);
+    }
+
+    public function testVariadic(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/Variadic.php'], [
+            [sprintf(UnusedFormalParameterRule::ERROR_MESSAGE_TEMPLATE, 'values'), 12],
+        ]);
+    }
+
+    public function testByReference(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ByReference.php'], [
+            [sprintf(UnusedFormalParameterRule::ERROR_MESSAGE_TEMPLATE, 'out'), 7],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(UnusedFormalParameterRule::class);
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/DisallowInheritDocTest.php
+++ b/tests/Rules/UnusedFormalParameter/DisallowInheritDocTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter;
+
+use Orrison\MeliorStan\Rules\UnusedFormalParameter\UnusedFormalParameterRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<UnusedFormalParameterRule>
+ */
+class DisallowInheritDocTest extends RuleTestCase
+{
+    public function testInheritDocReported(): void
+    {
+        // Disable overriding allowance via the inheritdoc-only config so the
+        // override skip does not mask the inheritdoc behavior under test.
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/InheritDocParent.php',
+                __DIR__ . '/Fixture/InheritDocChild.php',
+            ],
+            [
+                [sprintf(UnusedFormalParameterRule::ERROR_MESSAGE_TEMPLATE, 'name'), 10],
+            ],
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/disallow_inheritdoc.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(UnusedFormalParameterRule::class);
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/DisallowOverridingMethodsTest.php
+++ b/tests/Rules/UnusedFormalParameter/DisallowOverridingMethodsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter;
+
+use Orrison\MeliorStan\Rules\UnusedFormalParameter\UnusedFormalParameterRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<UnusedFormalParameterRule>
+ */
+class DisallowOverridingMethodsTest extends RuleTestCase
+{
+    public function testOverridingMethodReported(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/OverridingParent.php',
+                __DIR__ . '/Fixture/OverridingChild.php',
+            ],
+            [
+                [sprintf(UnusedFormalParameterRule::ERROR_MESSAGE_TEMPLATE, 'name'), 7],
+            ],
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/disallow_overriding.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(UnusedFormalParameterRule::class);
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/ExceptionsTest.php
+++ b/tests/Rules/UnusedFormalParameter/ExceptionsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter;
+
+use Orrison\MeliorStan\Rules\UnusedFormalParameter\UnusedFormalParameterRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<UnusedFormalParameterRule>
+ */
+class ExceptionsTest extends RuleTestCase
+{
+    public function testExceptionsAreSkipped(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ExceptionsFixture.php'], [
+            [sprintf(UnusedFormalParameterRule::ERROR_MESSAGE_TEMPLATE, 'reported'), 7],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/with_exceptions.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(UnusedFormalParameterRule::class);
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/AbstractMethod.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/AbstractMethod.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+abstract class AbstractMethod
+{
+    abstract public function doSomething(int $value, string $name): void;
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/ArrowFunctionUses.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/ArrowFunctionUses.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+use Closure;
+
+class ArrowFunctionUses
+{
+    public function wrap(int $outer): Closure
+    {
+        return fn () => $outer + 1;
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/BasicUnused.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/BasicUnused.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class BasicUnused
+{
+    public function doSomething(int $used, int $unused): int
+    {
+        return $used + 1;
+    }
+}
+
+function basic_unused_function(int $used, int $unused): int
+{
+    return $used + 1;
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/ByReference.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/ByReference.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class ByReference
+{
+    public function fill(int &$out): void {}
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/ClosureUseInside.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/ClosureUseInside.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+use Closure;
+
+class ClosureUseInside
+{
+    public function wrap(int $outer): Closure
+    {
+        return function () use ($outer) {
+            return $outer + 1;
+        };
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/CompactParam.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/CompactParam.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class CompactParam
+{
+    public function build(int $a, int $b): array
+    {
+        return compact('a', 'b');
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/ExceptionsFixture.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/ExceptionsFixture.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class ExceptionsFixture
+{
+    public function handle(int $used, int $unused, int $reported): int
+    {
+        return $used;
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/FuncGetArgs.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/FuncGetArgs.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class FuncGetArgs
+{
+    public function variadicLike(int $a, int $b, int $c): array
+    {
+        return func_get_args();
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/InheritDocChild.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/InheritDocChild.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class InheritDocChild extends InheritDocParent
+{
+    /**
+     * @inheritdoc
+     */
+    public function handle(int $value, string $name): void
+    {
+        echo $value;
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/InheritDocParent.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/InheritDocParent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class InheritDocParent
+{
+    public function handle(int $value, string $name): void
+    {
+        echo $value . $name;
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/InterfaceMethod.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/InterfaceMethod.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+interface InterfaceMethod
+{
+    public function handle(int $value, string $name): void;
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/MagicMethods.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/MagicMethods.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class MagicMethods
+{
+    public function __call(string $name, array $args): void {}
+
+    public function __set(string $name, mixed $value): void {}
+
+    public function __get(string $name): mixed
+    {
+        return null;
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/OverridingChild.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/OverridingChild.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class OverridingChild extends OverridingParent
+{
+    public function process(int $value, string $name): void
+    {
+        echo $value;
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/OverridingParent.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/OverridingParent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class OverridingParent
+{
+    public function process(int $value, string $name): void
+    {
+        echo $value . $name;
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/PromotedConstructor.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/PromotedConstructor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class PromotedConstructor
+{
+    public function __construct(
+        public int $x,
+        protected string $y,
+        private float $z,
+    ) {}
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/VariableVariable.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/VariableVariable.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class VariableVariable
+{
+    public function dynamic(string $name, int $value): void
+    {
+        $$name = $value;
+        echo $$name;
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/Fixture/Variadic.php
+++ b/tests/Rules/UnusedFormalParameter/Fixture/Variadic.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\UnusedFormalParameter\Fixture;
+
+class Variadic
+{
+    public function usedVariadic(int ...$values): int
+    {
+        return array_sum($values);
+    }
+
+    public function unusedVariadic(int ...$values): int
+    {
+        return 0;
+    }
+}

--- a/tests/Rules/UnusedFormalParameter/config/configured_rule.neon
+++ b/tests/Rules/UnusedFormalParameter/config/configured_rule.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\UnusedFormalParameter\UnusedFormalParameterRule

--- a/tests/Rules/UnusedFormalParameter/config/disallow_inheritdoc.neon
+++ b/tests/Rules/UnusedFormalParameter/config/disallow_inheritdoc.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\UnusedFormalParameter\UnusedFormalParameterRule
+
+parameters:
+    meliorstan:
+        unused_formal_parameter:
+            allow_unused_with_inheritdoc: false
+            allow_overriding_methods: false

--- a/tests/Rules/UnusedFormalParameter/config/disallow_overriding.neon
+++ b/tests/Rules/UnusedFormalParameter/config/disallow_overriding.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\UnusedFormalParameter\UnusedFormalParameterRule
+
+parameters:
+    meliorstan:
+        unused_formal_parameter:
+            allow_overriding_methods: false

--- a/tests/Rules/UnusedFormalParameter/config/with_exceptions.neon
+++ b/tests/Rules/UnusedFormalParameter/config/with_exceptions.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\UnusedFormalParameter\UnusedFormalParameterRule
+
+parameters:
+    meliorstan:
+        unused_formal_parameter:
+            exceptions:
+                - unused


### PR DESCRIPTION
This pull request introduces a new rule, `UnusedFormalParameter`, to detect unused function, method, and closure parameters, bringing PHPMD parity for this check to the codebase. It also clarifies that detection of unused private methods and fields is already covered by PHPStan core, and provides documentation and configuration for these behaviors.

**New rule and configuration:**

* Added the `UnusedFormalParameter` rule, which flags unused parameters in functions, methods, and closures. The rule is configurable to allow exceptions for `@inheritdoc` methods, overriding methods, and specific parameter names. [[1]](diffhunk://#diff-e201190617607b1d2d465461fd76381ecd28a8de4fb396053a0e82420881b6afR1-R165)], [[2]](diffhunk://#diff-7505f2112059fc98f93f8dcd48c6c5082bf9fda6cedc8bf8131a0a18d6f603d1R1-R31)])
* Updated configuration schema (`config/extension.neon`) to support the new rule and its options, including default values. [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R80-R84)], [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R150-R153)], [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R254-R259)])
* Added `inheritdoc` to the dictionary for spellchecking. ([[.harper-dictionary.txtR7](diffhunk://#diff-f2066988b26a555c9a6fb46d67feb83391d299a9855000806d6e3cda9a37e01aR7)])

**Documentation improvements:**

* Added comprehensive documentation for the new `UnusedFormalParameter` rule, including configuration, usage, and examples. ([[docs/UnusedFormalParameter.mdR1-R165](diffhunk://#diff-e201190617607b1d2d465461fd76381ecd28a8de4fb396053a0e82420881b6afR1-R165)])
* Added documentation clarifying that `UnusedPrivateMethod` and `UnusedPrivateField` are already handled by PHPStan core, with instructions for users on enabling and customizing these checks. [[1]](diffhunk://#diff-3aa33fcff24b89feae8da20488a2a31d58a47533bb99f426459468ab47d949c6R1-R56)], [[2]](diffhunk://#diff-e898e9afab09f025efb0c534db61926568a58768eed9c143e5f3a45fb120d08cR1-R70)])
* Updated `README.md` to mention the new rule and to document that `UnusedPrivateMethod` and `UnusedPrivateField` are covered by PHPStan, with references to their equivalents and how to enable them. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102)], [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124-R132)])

**Key changes:**

**1. New Unused Parameter Rule**
- Introduced `UnusedFormalParameter` rule with configuration and documentation. [[1]](diffhunk://#diff-e201190617607b1d2d465461fd76381ecd28a8de4fb396053a0e82420881b6afR1-R165)], [[2]](diffhunk://#diff-7505f2112059fc98f93f8dcd48c6c5082bf9fda6cedc8bf8131a0a18d6f603d1R1-R31)], [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R80-R84)], [[4]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R150-R153)], [[5]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R254-R259)], [[6]](diffhunk://#diff-f2066988b26a555c9a6fb46d67feb83391d299a9855000806d6e3cda9a37e01aR7)], [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102)])

**2. Documentation for PHPStan Core Coverage**
- Added/updated documentation for `UnusedPrivateMethod` and `UnusedPrivateField` to clarify these are handled by PHPStan core, not MeliorStan. [[1]](diffhunk://#diff-3aa33fcff24b89feae8da20488a2a31d58a47533bb99f426459468ab47d949c6R1-R56)], [[2]](diffhunk://#diff-e898e9afab09f025efb0c534db61926568a58768eed9c143e5f3a45fb120d08cR1-R70)], [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124-R132)])

These changes improve static analysis coverage and clarify the boundaries between MeliorStan and PHPStan core functionality.

Closes https://github.com/Orrison/MeliorStan/issues/61
Closes https://github.com/Orrison/MeliorStan/issues/58
Closes https://github.com/Orrison/MeliorStan/issues/60