### PR TITLE
Finish the Design Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ parameters:
 
 | Rule | Description | Target |
 |------|-------------|---------|
+| **[DevelopmentCodeFragment](docs/DevelopmentCodeFragment.md)** | Detects calls to development/debug functions like var_dump, print_r, etc. | Function Calls |
 | **[EmptyCatchBlock](docs/EmptyCatchBlock.md)** | Detects and reports empty catch blocks in exception handling | Catch Blocks |
 | **[ForbidCountInLoopExpressions](docs/ForbidCountInLoopExpressions.md)** | Detects usage of count() or sizeof() in loop conditions | Loop Conditions |
 | **[ForbidEvalExpressions](docs/ForbidEvalExpressions.md)** | Detects and reports usage of eval expressions | Eval Expressions |

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ parameters:
 | **[ForbidExitExpressions](docs/ForbidExitExpressions.md)** | Detects and reports usage of exit and die expressions | Exit Expressions |
 | **[ForbidGotoStatements](docs/ForbidGotoStatements.md)** | Detects and reports usage of goto statements | Goto Statements |
 | **[CouplingBetweenObjects](docs/CouplingBetweenObjects.md)** | Detects classes with too many type dependencies | Classes, Interfaces, Traits, Enums |
+| **[DepthOfInheritance](docs/DepthOfInheritance.md)** | Detects classes with excessively deep inheritance chains | Classes |
 | **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |
 | **[TooManyMethods](docs/TooManyMethods.md)** | Detects classes with too many methods | Classes, Interfaces, Traits, Enums |

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ parameters:
 | **[ForbidEvalExpressions](docs/ForbidEvalExpressions.md)** | Detects and reports usage of eval expressions | Eval Expressions |
 | **[ForbidExitExpressions](docs/ForbidExitExpressions.md)** | Detects and reports usage of exit and die expressions | Exit Expressions |
 | **[ForbidGotoStatements](docs/ForbidGotoStatements.md)** | Detects and reports usage of goto statements | Goto Statements |
+| **[CouplingBetweenObjects](docs/CouplingBetweenObjects.md)** | Detects classes with too many type dependencies | Classes, Interfaces, Traits, Enums |
 | **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |
 | **[TooManyMethods](docs/TooManyMethods.md)** | Detects classes with too many methods | Classes, Interfaces, Traits, Enums |

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -91,6 +91,11 @@ parametersSchema:
             excluded_types: arrayOf(string()),
             count_attributes: bool(),
         ]),
+        depth_of_inheritance: structure([
+            maximum: int(),
+            excluded_namespaces: arrayOf(string()),
+            ignored_classes: arrayOf(string()),
+        ]),
     ])
 
 # default parameters
@@ -167,6 +172,10 @@ parameters:
             excluded_namespaces: []
             excluded_types: []
             count_attributes: true
+        depth_of_inheritance:
+            maximum: 6
+            excluded_namespaces: []
+            ignored_classes: []
 
 services:
     -
@@ -284,3 +293,9 @@ services:
             - %meliorstan.coupling_between_objects.excluded_namespaces%
             - %meliorstan.coupling_between_objects.excluded_types%
             - %meliorstan.coupling_between_objects.count_attributes%
+    -
+        factory: Orrison\MeliorStan\Rules\DepthOfInheritance\Config
+        arguments:
+            - %meliorstan.depth_of_inheritance.maximum%
+            - %meliorstan.depth_of_inheritance.excluded_namespaces%
+            - %meliorstan.depth_of_inheritance.ignored_classes%

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -82,6 +82,9 @@ parametersSchema:
             allow_overriding_methods: bool(),
             exceptions: arrayOf(string()),
         ]),
+        development_code_fragment: structure([
+            unwanted_functions: arrayOf(string()),
+        ]),
     ])
 
 # default parameters
@@ -151,6 +154,8 @@ parameters:
             allow_unused_with_inheritdoc: true
             allow_overriding_methods: true
             exceptions: []
+        development_code_fragment:
+            unwanted_functions: []
 
 services:
     -
@@ -257,3 +262,7 @@ services:
             - %meliorstan.unused_formal_parameter.allow_unused_with_inheritdoc%
             - %meliorstan.unused_formal_parameter.allow_overriding_methods%
             - %meliorstan.unused_formal_parameter.exceptions%
+    -
+        factory: Orrison\MeliorStan\Rules\DevelopmentCodeFragment\Config
+        arguments:
+            - %meliorstan.development_code_fragment.unwanted_functions%

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -85,6 +85,12 @@ parametersSchema:
         development_code_fragment: structure([
             unwanted_functions: arrayOf(string()),
         ]),
+        coupling_between_objects: structure([
+            maximum: int(),
+            excluded_namespaces: arrayOf(string()),
+            excluded_types: arrayOf(string()),
+            count_attributes: bool(),
+        ]),
     ])
 
 # default parameters
@@ -156,6 +162,11 @@ parameters:
             exceptions: []
         development_code_fragment:
             unwanted_functions: []
+        coupling_between_objects:
+            maximum: 13
+            excluded_namespaces: []
+            excluded_types: []
+            count_attributes: true
 
 services:
     -
@@ -266,3 +277,10 @@ services:
         factory: Orrison\MeliorStan\Rules\DevelopmentCodeFragment\Config
         arguments:
             - %meliorstan.development_code_fragment.unwanted_functions%
+    -
+        factory: Orrison\MeliorStan\Rules\CouplingBetweenObjects\Config
+        arguments:
+            - %meliorstan.coupling_between_objects.maximum%
+            - %meliorstan.coupling_between_objects.excluded_namespaces%
+            - %meliorstan.coupling_between_objects.excluded_types%
+            - %meliorstan.coupling_between_objects.count_attributes%

--- a/docs/CouplingBetweenObjects.md
+++ b/docs/CouplingBetweenObjects.md
@@ -1,0 +1,203 @@
+# CouplingBetweenObjects
+
+Detects classes with too many type dependencies (high coupling between objects).
+
+A class with too many dependencies has negative impacts on stability, maintainability, and understandability. This rule counts the number of unique external types referenced by a class and flags it when the count exceeds a configurable threshold. This is based on the Coupling Between Objects (CBO) metric from object-oriented design.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `maximum`
+- **Type**: `int`
+- **Default**: `13`
+- **Description**: The maximum number of unique type dependencies a class can have before triggering a violation. Matches the PHPMD default.
+
+### `excluded_namespaces`
+- **Type**: `array<string>`
+- **Default**: `[]`
+- **Description**: Namespace prefixes to exclude from the coupling count. Types whose fully-qualified name starts with any of these prefixes will not be counted. Useful for excluding framework namespaces like `Illuminate\` in Laravel projects.
+
+### `excluded_types`
+- **Type**: `array<string>`
+- **Default**: `[]`
+- **Description**: Specific fully-qualified class names to exclude from the coupling count. Useful for excluding ubiquitous types like `Carbon\Carbon` or `Illuminate\Support\Collection`.
+
+### `count_attributes`
+- **Type**: `bool`
+- **Default**: `true`
+- **Description**: Whether PHP 8 attributes (`#[SomeAttribute]`) should count toward the coupling value. When enabled, attribute types used on the class, properties, methods, and parameters are included in the count.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule
+
+parameters:
+    meliorstan:
+        coupling_between_objects:
+            maximum: 13
+            excluded_namespaces: []
+            excluded_types: []
+            count_attributes: true
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+use App\Services\UserService;
+use App\Services\OrderService;
+use App\Services\PaymentService;
+use App\Repositories\UserRepository;
+// ... many more imports
+
+// ✗ Error: Class has coupling value of 14, exceeds maximum of 13
+class OrderController
+{
+    public function __construct(
+        private UserService $userService,
+        private OrderService $orderService,
+        private PaymentService $paymentService,
+        private UserRepository $userRepo,
+        // ... 10 more dependencies
+    ) {}
+
+    public function process(OrderRequest $request): OrderResponse
+    {
+        // uses many different types...
+    }
+}
+
+// ✓ Valid: Class with few dependencies (3 unique types)
+class SimpleService
+{
+    public function __construct(
+        private UserRepository $repo,
+    ) {}
+
+    public function find(int $id): User
+    {
+        return $this->repo->find($id);
+    }
+}
+```
+
+### Configuration Examples
+
+#### Excluding Laravel Framework Namespaces
+
+```neon
+parameters:
+    meliorstan:
+        coupling_between_objects:
+            excluded_namespaces:
+                - 'Illuminate\'
+```
+
+```php
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
+use App\Models\User;
+use App\Services\UserService;
+
+// ✓ Now valid: Illuminate types are excluded, only 2 non-framework types count
+class UserController
+{
+    public function index(Request $request, UserService $service): JsonResponse
+    {
+        $users = $service->all();
+
+        return new JsonResponse($users);
+    }
+}
+```
+
+#### Excluding Specific Types
+
+```neon
+parameters:
+    meliorstan:
+        coupling_between_objects:
+            excluded_types:
+                - 'Carbon\Carbon'
+                - 'Illuminate\Support\Collection'
+```
+
+```php
+<?php
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+// ✓ Carbon and Collection are excluded from the coupling count
+class ReportService
+{
+    public function generate(Carbon $from, Carbon $to): Collection
+    {
+        // ...
+    }
+}
+```
+
+#### Disabling Attribute Counting
+
+```neon
+parameters:
+    meliorstan:
+        coupling_between_objects:
+            count_attributes: false
+```
+
+```php
+<?php
+
+use App\Attributes\Validate;
+use App\Attributes\Authorize;
+use App\Attributes\Cache;
+
+// ✓ Now valid: attribute types are not counted toward coupling
+#[Authorize]
+#[Cache]
+class UserController
+{
+    #[Validate]
+    public function store(): void {}
+}
+```
+
+## What Counts as Coupling
+
+The rule counts unique external type references from the following sources:
+
+- **Inheritance**: `extends` and `implements` clauses
+- **Trait usage**: `use` statements inside the class
+- **Property types**: Typed property declarations
+- **Method parameter types**: Type hints on method parameters
+- **Method return types**: Return type declarations
+- **Object instantiation**: `new ClassName()` expressions
+- **Static access**: `ClassName::method()`, `ClassName::$property`, `ClassName::CONSTANT`
+- **Exception handling**: Types in `catch` blocks
+- **Type checks**: `instanceof` expressions
+- **Closure/arrow function types**: Parameter and return types in closures and arrow functions
+- **PHP 8 attributes**: `#[AttributeName]` on the class, properties, methods, and parameters (when `count_attributes` is enabled)
+
+## Important Notes
+
+- **Deduplication**: Each unique type is counted only once, regardless of how many times it appears. A type used as a property, parameter, and in a `new` expression still counts as one dependency.
+- **Built-in types excluded**: PHP built-in types (`int`, `string`, `bool`, `array`, `void`, `mixed`, `null`, `self`, `static`, `parent`, etc.) are never counted.
+- **Self-references excluded**: References to the class itself are not counted.
+- **All class-like types**: The rule applies to classes, interfaces, traits, and enums.
+- **Anonymous classes skipped**: Anonymous classes are not analyzed.

--- a/docs/DepthOfInheritance.md
+++ b/docs/DepthOfInheritance.md
@@ -1,0 +1,125 @@
+# DepthOfInheritance
+
+Detects classes with excessively deep inheritance chains.
+
+A class with many ancestors is tightly coupled to its entire hierarchy, making it fragile, hard to test, and difficult to understand. This rule counts the number of parent classes in a class's inheritance chain and flags it when the depth exceeds a configurable threshold. This is based on the Depth of Inheritance Tree (DIT) metric from object-oriented design.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `maximum`
+- **Type**: `int`
+- **Default**: `6`
+- **Description**: The maximum allowed inheritance depth before triggering a violation. Matches the PHPMD default. A class that extends 6 or fewer parent classes will not be flagged.
+
+### `excluded_namespaces`
+- **Type**: `array<string>`
+- **Default**: `[]`
+- **Description**: Namespace prefixes whose ancestors don't count toward the inheritance depth. Ancestors whose fully-qualified name starts with any of these prefixes are skipped when counting depth, but the walk continues past them. Useful for excluding framework namespaces like `Illuminate\` in Laravel projects where base classes add several levels of inheritance outside your control.
+
+### `ignored_classes`
+- **Type**: `array<string>`
+- **Default**: `[]`
+- **Description**: Fully-qualified class names to skip entirely. Classes matching any entry in this list will not be checked by the rule at all. Useful for classes that naturally have deep chains due to framework design, such as Eloquent models or middleware.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\DepthOfInheritance\DepthOfInheritanceRule
+
+parameters:
+    meliorstan:
+        depth_of_inheritance:
+            maximum: 6
+            excluded_namespaces: []
+            ignored_classes: []
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class Animal {}
+class Mammal extends Animal {}
+class Canine extends Mammal {}
+class Dog extends Canine {}           // ✓ Valid — depth 3
+class Labrador extends Dog {}         // ✓ Valid — depth 4
+class ChocolateLab extends Labrador {} // ✓ Valid — depth 5
+class MiniChocolateLab extends ChocolateLab {} // ✓ Valid — depth 6
+class TinyMiniChocolateLab extends MiniChocolateLab {} // ✗ Error: depth 7 exceeds maximum of 6
+```
+
+### Configuration Examples
+
+#### Lower Maximum
+
+```neon
+parameters:
+    meliorstan:
+        depth_of_inheritance:
+            maximum: 3
+```
+
+```php
+<?php
+
+class Base {}
+class Level1 extends Base {}
+class Level2 extends Level1 {}
+class Level3 extends Level2 {}  // ✓ Valid — depth 3
+class Level4 extends Level3 {}  // ✗ Error: depth 4 exceeds maximum of 3
+```
+
+#### Excluded Namespaces
+
+```neon
+parameters:
+    meliorstan:
+        depth_of_inheritance:
+            maximum: 3
+            excluded_namespaces:
+                - Illuminate\
+```
+
+```php
+<?php
+
+// Illuminate\Routing\Controller -> Illuminate\Foundation\Bus\... (framework depth ignored)
+class AppController extends \Illuminate\Routing\Controller {}    // ✓ Now valid — vendor ancestors excluded
+class UserController extends AppController {}                     // ✓ Now valid — depth 1 (only AppController counts)
+```
+
+#### Ignored Classes
+
+```neon
+parameters:
+    meliorstan:
+        depth_of_inheritance:
+            maximum: 3
+            ignored_classes:
+                - App\Models\SpecialModel
+```
+
+```php
+<?php
+
+// App\Models\SpecialModel has deep inheritance but is ignored entirely
+class SpecialModel extends DeepFrameworkBase {} // ✓ Now valid — class is skipped
+```
+
+## Important Notes
+
+- This rule only checks classes. Interfaces, traits, and enums are not analyzed.
+- Anonymous classes are skipped.
+- When using `excluded_namespaces`, the rule still walks past excluded ancestors to count any non-excluded ancestors further up the chain.
+- The `ignored_classes` option skips the check entirely for the specified class — it does not affect depth counting for other classes that may extend it.

--- a/docs/DevelopmentCodeFragment.md
+++ b/docs/DevelopmentCodeFragment.md
@@ -1,0 +1,90 @@
+# DevelopmentCodeFragment
+
+Detects calls to development and debugging functions that should not appear in production code.
+
+Functions like `var_dump()`, `print_r()`, `dd()`, `dump()`, and `ray()` are typically used during development and are often accidentally left in production code. This rule flags these calls so they can be removed before deployment.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `unwanted_functions`
+- **Type**: `array` of `string`
+- **Default**: `['var_dump', 'print_r', 'debug_zval_dump', 'debug_print_backtrace', 'dd', 'dump', 'ray']`
+- **Description**: A list of function names to flag as development code. When set to a non-empty array, this completely replaces the default list. Function name matching is case-insensitive.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\DevelopmentCodeFragment\DevelopmentCodeFragmentRule
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class UserService
+{
+    public function getUser(int $id): array
+    {
+        $user = $this->findUser($id);
+        var_dump($user);              // ✗ Error: Call to development/debug function var_dump() is discouraged.
+        print_r($user);              // ✗ Error: Call to development/debug function print_r() is discouraged.
+        debug_zval_dump($user);      // ✗ Error: Call to development/debug function debug_zval_dump() is discouraged.
+        debug_print_backtrace();     // ✗ Error: Call to development/debug function debug_print_backtrace() is discouraged.
+        dd($user);                   // ✗ Error: Call to development/debug function dd() is discouraged.
+        dump($user);                 // ✗ Error: Call to development/debug function dump() is discouraged.
+        ray($user);                  // ✗ Error: Call to development/debug function ray() is discouraged.
+
+        echo $user['name'];         // ✓ Valid
+        count($user);               // ✓ Valid
+        array_map(fn ($v) => $v, $user); // ✓ Valid
+
+        return $user;
+    }
+}
+```
+
+### Configuration Examples
+
+#### Custom Unwanted Functions
+
+Override the default list to flag framework-specific debug helpers instead:
+
+```neon
+parameters:
+    meliorstan:
+        development_code_fragment:
+            unwanted_functions:
+                - dump
+                - dd
+```
+
+```php
+<?php
+
+class Example
+{
+    public function process(array $data): void
+    {
+        dump($data);     // ✗ Error: Call to development/debug function dump() is discouraged.
+        dd($data);       // ✗ Error: Call to development/debug function dd() is discouraged.
+        var_dump($data); // ✓ Now valid (not in custom list)
+    }
+}
+```
+
+## Important Notes
+
+- Setting `unwanted_functions` to a non-empty list **replaces** the defaults entirely; it does not merge with them. To keep the defaults and add more, include all desired function names in your list.
+- Function name matching is case-insensitive (`VAR_DUMP` and `var_dump` are treated the same).
+- This rule only detects direct function calls. It does not detect calls made via variables (e.g., `$fn = 'var_dump'; $fn($data);`).

--- a/src/Rules/CouplingBetweenObjects/Config.php
+++ b/src/Rules/CouplingBetweenObjects/Config.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\CouplingBetweenObjects;
+
+class Config
+{
+    /**
+     * @param int $maximum Maximum number of unique type dependencies allowed.
+     * @param array<string> $excludedNamespaces Namespace prefixes to exclude from coupling count.
+     * @param array<string> $excludedTypes Specific FQCNs to exclude from coupling count.
+     * @param bool $countAttributes Whether PHP 8 attributes count toward coupling.
+     */
+    public function __construct(
+        protected int $maximum,
+        protected array $excludedNamespaces,
+        protected array $excludedTypes,
+        protected bool $countAttributes,
+    ) {}
+
+    public function getMaximum(): int
+    {
+        return $this->maximum;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getExcludedNamespaces(): array
+    {
+        return $this->excludedNamespaces;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getExcludedTypes(): array
+    {
+        return $this->excludedTypes;
+    }
+
+    public function getCountAttributes(): bool
+    {
+        return $this->countAttributes;
+    }
+}

--- a/src/Rules/CouplingBetweenObjects/CouplingBetweenObjectsRule.php
+++ b/src/Rules/CouplingBetweenObjects/CouplingBetweenObjectsRule.php
@@ -1,0 +1,374 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\CouplingBetweenObjects;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Trait_;
+use PhpParser\Node\UnionType;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassLike>
+ */
+class CouplingBetweenObjectsRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = '%s "%s" has a coupling between objects value of %d, which exceeds the maximum of %d. Consider reducing dependencies.';
+
+    /** @var array<string, true> */
+    private const array BUILTIN_TYPES = [
+        'int' => true,
+        'integer' => true,
+        'float' => true,
+        'double' => true,
+        'string' => true,
+        'bool' => true,
+        'boolean' => true,
+        'array' => true,
+        'object' => true,
+        'mixed' => true,
+        'void' => true,
+        'null' => true,
+        'never' => true,
+        'callable' => true,
+        'iterable' => true,
+        'self' => true,
+        'static' => true,
+        'parent' => true,
+        'true' => true,
+        'false' => true,
+    ];
+
+    public function __construct(
+        protected Config $config,
+    ) {}
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassLike::class;
+    }
+
+    /**
+     * @param ClassLike $node
+     *
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        $coupledTypes = $this->collectCoupledTypes($node);
+
+        $ownName = $this->resolveOwnClassName($node);
+        $filteredTypes = $this->filterTypes($coupledTypes, $ownName);
+
+        $count = count($filteredTypes);
+
+        if ($count <= $this->config->getMaximum()) {
+            return [];
+        }
+
+        $nodeType = $this->getNodeTypeName($node);
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    self::ERROR_MESSAGE_TEMPLATE,
+                    $nodeType,
+                    $node->name->toString(),
+                    $count,
+                    $this->config->getMaximum()
+                )
+            )
+                ->identifier('MeliorStan.couplingBetweenObjects')
+                ->build(),
+        ];
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    protected function collectCoupledTypes(ClassLike $node): array
+    {
+        $types = [];
+        $nodeFinder = new NodeFinder();
+
+        // extends / implements
+        $this->collectInheritanceTypes($node, $types);
+
+        // Trait uses
+        foreach ($node->getTraitUses() as $traitUse) {
+            foreach ($traitUse->traits as $trait) {
+                $types[$trait->toString()] = true;
+            }
+        }
+
+        // Property types
+        foreach ($nodeFinder->findInstanceOf($node->stmts, Property::class) as $property) {
+            $this->collectFromTypeNode($property->type, $types);
+        }
+
+        // Method parameter types and return types
+        foreach ($nodeFinder->findInstanceOf($node->stmts, ClassMethod::class) as $method) {
+            foreach ($method->params as $param) {
+                $this->collectFromTypeNode($param->type, $types);
+            }
+
+            $this->collectFromTypeNode($method->returnType, $types);
+        }
+
+        // Closure parameter types and return types
+        foreach ($nodeFinder->findInstanceOf($node->stmts, Closure::class) as $closure) {
+            foreach ($closure->params as $param) {
+                $this->collectFromTypeNode($param->type, $types);
+            }
+
+            $this->collectFromTypeNode($closure->returnType, $types);
+        }
+
+        // Arrow function parameter types and return types
+        foreach ($nodeFinder->findInstanceOf($node->stmts, ArrowFunction::class) as $arrowFunction) {
+            foreach ($arrowFunction->params as $param) {
+                $this->collectFromTypeNode($param->type, $types);
+            }
+
+            $this->collectFromTypeNode($arrowFunction->returnType, $types);
+        }
+
+        // new ClassName()
+        foreach ($nodeFinder->findInstanceOf($node->stmts, New_::class) as $newExpr) {
+            if ($newExpr->class instanceof Name) {
+                $types[$newExpr->class->toString()] = true;
+            }
+        }
+
+        // ClassName::method()
+        foreach ($nodeFinder->findInstanceOf($node->stmts, StaticCall::class) as $staticCall) {
+            if ($staticCall->class instanceof Name) {
+                $types[$staticCall->class->toString()] = true;
+            }
+        }
+
+        // ClassName::$prop
+        foreach ($nodeFinder->findInstanceOf($node->stmts, StaticPropertyFetch::class) as $staticPropFetch) {
+            if ($staticPropFetch->class instanceof Name) {
+                $types[$staticPropFetch->class->toString()] = true;
+            }
+        }
+
+        // ClassName::CONST
+        foreach ($nodeFinder->findInstanceOf($node->stmts, ClassConstFetch::class) as $constFetch) {
+            if ($constFetch->class instanceof Name) {
+                $types[$constFetch->class->toString()] = true;
+            }
+        }
+
+        // catch (Type $e)
+        foreach ($nodeFinder->findInstanceOf($node->stmts, Catch_::class) as $catch) {
+            foreach ($catch->types as $catchType) {
+                $types[$catchType->toString()] = true;
+            }
+        }
+
+        // instanceof Type
+        foreach ($nodeFinder->findInstanceOf($node->stmts, Instanceof_::class) as $instanceOf) {
+            if ($instanceOf->class instanceof Name) {
+                $types[$instanceOf->class->toString()] = true;
+            }
+        }
+
+        // PHP 8 attributes
+        if ($this->config->getCountAttributes()) {
+            foreach ($nodeFinder->findInstanceOf($node->stmts, Attribute::class) as $attribute) {
+                $types[$attribute->name->toString()] = true;
+            }
+
+            // Also check class-level attributes
+            foreach ($node->attrGroups as $attrGroup) {
+                foreach ($attrGroup->attrs as $attribute) {
+                    $types[$attribute->name->toString()] = true;
+                }
+            }
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param array<string, true> $types
+     */
+    protected function collectInheritanceTypes(ClassLike $node, array &$types): void
+    {
+        if ($node instanceof Class_) {
+            if ($node->extends !== null) {
+                $types[$node->extends->toString()] = true;
+            }
+
+            foreach ($node->implements as $implement) {
+                $types[$implement->toString()] = true;
+            }
+        }
+
+        if ($node instanceof Interface_) {
+            foreach ($node->extends as $extend) {
+                $types[$extend->toString()] = true;
+            }
+        }
+
+        if ($node instanceof Enum_) {
+            foreach ($node->implements as $implement) {
+                $types[$implement->toString()] = true;
+            }
+        }
+    }
+
+    /**
+     * @param array<string, true> $types
+     */
+    protected function collectFromTypeNode(?Node $typeNode, array &$types): void
+    {
+        if ($typeNode === null) {
+            return;
+        }
+
+        if ($typeNode instanceof Name) {
+            $types[$typeNode->toString()] = true;
+
+            return;
+        }
+
+        if ($typeNode instanceof Identifier) {
+            // Built-in types like int, string, etc. - will be filtered later
+            return;
+        }
+
+        if ($typeNode instanceof NullableType) {
+            $this->collectFromTypeNode($typeNode->type, $types);
+
+            return;
+        }
+
+        if ($typeNode instanceof UnionType) {
+            foreach ($typeNode->types as $innerType) {
+                $this->collectFromTypeNode($innerType, $types);
+            }
+
+            return;
+        }
+
+        if ($typeNode instanceof IntersectionType) {
+            foreach ($typeNode->types as $innerType) {
+                $this->collectFromTypeNode($innerType, $types);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, true> $types
+     *
+     * @return array<string, true>
+     */
+    protected function filterTypes(array $types, string $ownClassName): array
+    {
+        $excludedNamespaces = $this->config->getExcludedNamespaces();
+        $excludedTypes = array_flip($this->config->getExcludedTypes());
+
+        foreach ($types as $typeName => $_) {
+            $lowerType = strtolower($typeName);
+
+            // Filter built-in types
+            if (isset(self::BUILTIN_TYPES[$lowerType])) {
+                unset($types[$typeName]);
+
+                continue;
+            }
+
+            // Filter self-references
+            if ($typeName === $ownClassName) {
+                unset($types[$typeName]);
+
+                continue;
+            }
+
+            // Filter excluded types
+            if (isset($excludedTypes[$typeName])) {
+                unset($types[$typeName]);
+
+                continue;
+            }
+
+            // Filter excluded namespaces
+            foreach ($excludedNamespaces as $namespace) {
+                if (str_starts_with($typeName, $namespace)) {
+                    unset($types[$typeName]);
+
+                    break;
+                }
+            }
+        }
+
+        return $types;
+    }
+
+    protected function resolveOwnClassName(ClassLike $node): string
+    {
+        if (isset($node->namespacedName)) {
+            return $node->namespacedName->toString();
+        }
+
+        if ($node->name instanceof Identifier) {
+            return $node->name->toString();
+        }
+
+        return '';
+    }
+
+    protected function getNodeTypeName(ClassLike $node): string
+    {
+        if ($node instanceof Class_) {
+            return 'Class';
+        }
+
+        if ($node instanceof Interface_) {
+            return 'Interface';
+        }
+
+        if ($node instanceof Trait_) {
+            return 'Trait';
+        }
+
+        if ($node instanceof Enum_) {
+            return 'Enum';
+        }
+
+        return 'Class';
+    }
+}

--- a/src/Rules/DepthOfInheritance/Config.php
+++ b/src/Rules/DepthOfInheritance/Config.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\DepthOfInheritance;
+
+class Config
+{
+    /**
+     * @param int $maximum Maximum allowed inheritance depth.
+     * @param array<string> $excludedNamespaces Namespace prefixes whose ancestors don't count toward depth.
+     * @param array<string> $ignoredClasses FQCNs of classes to skip entirely.
+     */
+    public function __construct(
+        protected int $maximum,
+        protected array $excludedNamespaces,
+        protected array $ignoredClasses,
+    ) {}
+
+    public function getMaximum(): int
+    {
+        return $this->maximum;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getExcludedNamespaces(): array
+    {
+        return $this->excludedNamespaces;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getIgnoredClasses(): array
+    {
+        return $this->ignoredClasses;
+    }
+}

--- a/src/Rules/DepthOfInheritance/DepthOfInheritanceRule.php
+++ b/src/Rules/DepthOfInheritance/DepthOfInheritanceRule.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\DepthOfInheritance;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Class_>
+ */
+class DepthOfInheritanceRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = 'Class "%s" has an inheritance depth of %d, which exceeds the maximum of %d.';
+
+    public function __construct(
+        protected Config $config,
+        protected ReflectionProvider $reflectionProvider,
+    ) {}
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @param Class_ $node
+     *
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->isAnonymous()) {
+            return [];
+        }
+
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        $className = $node->namespacedName !== null
+            ? $node->namespacedName->toString()
+            : $node->name->toString();
+
+        if ($this->isIgnoredClass($className)) {
+            return [];
+        }
+
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        $depth = $this->calculateDepth($classReflection);
+
+        if ($depth <= $this->config->getMaximum()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    self::ERROR_MESSAGE_TEMPLATE,
+                    $node->name->toString(),
+                    $depth,
+                    $this->config->getMaximum()
+                )
+            )
+                ->identifier('MeliorStan.depthOfInheritance')
+                ->build(),
+        ];
+    }
+
+    protected function calculateDepth(ClassReflection $classReflection): int
+    {
+        $depth = 0;
+        $excludedNamespaces = $this->config->getExcludedNamespaces();
+        $current = $classReflection->getParentClass();
+
+        while ($current !== null) {
+            if (! $this->isInExcludedNamespace($current->getName(), $excludedNamespaces)) {
+                $depth++;
+            }
+
+            $current = $current->getParentClass();
+        }
+
+        return $depth;
+    }
+
+    protected function isIgnoredClass(string $className): bool
+    {
+        foreach ($this->config->getIgnoredClasses() as $ignoredClass) {
+            if ($className === $ignoredClass) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string> $excludedNamespaces
+     */
+    protected function isInExcludedNamespace(string $className, array $excludedNamespaces): bool
+    {
+        foreach ($excludedNamespaces as $namespace) {
+            if (str_starts_with($className, $namespace)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rules/DevelopmentCodeFragment/Config.php
+++ b/src/Rules/DevelopmentCodeFragment/Config.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\DevelopmentCodeFragment;
+
+class Config
+{
+    public const array DEFAULT_UNWANTED_FUNCTIONS = [
+        'var_dump',
+        'print_r',
+        'debug_zval_dump',
+        'debug_print_backtrace',
+        'dd',
+        'dump',
+        'ray',
+    ];
+
+    /** @var string[] */
+    protected array $unwantedFunctions;
+
+    /**
+     * @param string[] $unwantedFunctions
+     */
+    public function __construct(
+        array $unwantedFunctions = [],
+    ) {
+        $this->unwantedFunctions = $unwantedFunctions === [] ? self::DEFAULT_UNWANTED_FUNCTIONS : $unwantedFunctions;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getUnwantedFunctions(): array
+    {
+        return $this->unwantedFunctions;
+    }
+}

--- a/src/Rules/DevelopmentCodeFragment/DevelopmentCodeFragmentRule.php
+++ b/src/Rules/DevelopmentCodeFragment/DevelopmentCodeFragmentRule.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\DevelopmentCodeFragment;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FuncCall>
+ */
+class DevelopmentCodeFragmentRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = 'Call to development/debug function %s() is discouraged.';
+
+    public function __construct(
+        protected Config $config,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Name) {
+            return [];
+        }
+
+        $functionName = $node->name->toLowerString();
+
+        $unwantedFunctions = array_map('strtolower', $this->config->getUnwantedFunctions());
+
+        if (! in_array($functionName, $unwantedFunctions, true)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(self::ERROR_MESSAGE_TEMPLATE, $functionName)
+            )
+                ->identifier('MeliorStan.developmentCodeFragment')
+                ->build(),
+        ];
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/CountAttributesDisabledTest.php
+++ b/tests/Rules/CouplingBetweenObjects/CountAttributesDisabledTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects;
+
+use Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CouplingBetweenObjectsRule>
+ */
+class CountAttributesDisabledTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        // AttributeNoCouplingClass has 3 code deps (DepA, DepB, DepC) + 2 attributes.
+        // With count_attributes=false and maximum=3, only 3 code deps count -> passes.
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/AttributeNoCouplingClass.php',
+            ],
+            []
+        );
+    }
+
+    public function testAttributesCountWhenEnabled(): void
+    {
+        // AttributeCouplingClass has 3 code deps + 2 attributes = 5 total.
+        // But this test uses count_attributes=false, so only 3 -> passes.
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/AttributeCouplingClass.php',
+            ],
+            []
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/count_attributes_disabled.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CouplingBetweenObjectsRule::class);
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/CountAttributesEnabledTest.php
+++ b/tests/Rules/CouplingBetweenObjects/CountAttributesEnabledTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects;
+
+use Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CouplingBetweenObjectsRule>
+ */
+class CountAttributesEnabledTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        // AttributeCouplingClass has 3 code deps (DepA, DepB, DepC) + 2 attributes
+        // (SomeAttribute, AnotherAttribute) = 5 total.
+        // With maximum=3 and count_attributes=true (default), triggers error.
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/AttributeCouplingClass.php',
+            ],
+            [
+                [
+                    sprintf(CouplingBetweenObjectsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'AttributeCouplingClass', 5, 3),
+                    11,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/custom_maximum.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CouplingBetweenObjectsRule::class);
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/CustomMaximumTest.php
+++ b/tests/Rules/CouplingBetweenObjects/CustomMaximumTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects;
+
+use Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CouplingBetweenObjectsRule>
+ */
+class CustomMaximumTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/CustomMaximumHighClass.php',
+                __DIR__ . '/Fixture/CustomMaximumLowClass.php',
+            ],
+            [
+                [
+                    sprintf(CouplingBetweenObjectsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'CustomMaximumHighClass', 4, 3),
+                    10,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/custom_maximum.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CouplingBetweenObjectsRule::class);
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/DefaultOptionsTest.php
+++ b/tests/Rules/CouplingBetweenObjects/DefaultOptionsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects;
+
+use Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CouplingBetweenObjectsRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/HighCouplingClass.php',
+                __DIR__ . '/Fixture/LowCouplingClass.php',
+                __DIR__ . '/Fixture/DeduplicationClass.php',
+            ],
+            [
+                [
+                    sprintf(CouplingBetweenObjectsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'HighCouplingClass', 14, 13),
+                    20,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CouplingBetweenObjectsRule::class);
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/ExcludedNamespacesTest.php
+++ b/tests/Rules/CouplingBetweenObjects/ExcludedNamespacesTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects;
+
+use Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CouplingBetweenObjectsRule>
+ */
+class ExcludedNamespacesTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        // ExcludedNamespacesClass has 4 non-excluded deps (DepA-D) + 2 excluded deps.
+        // With maximum=3 and excluded namespace, only the 4 non-excluded count -> triggers error.
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ExcludedNamespacesClass.php',
+            ],
+            [
+                [
+                    sprintf(CouplingBetweenObjectsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ExcludedNamespacesClass', 4, 3),
+                    12,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/excluded_namespaces.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CouplingBetweenObjectsRule::class);
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/ExcludedTypesTest.php
+++ b/tests/Rules/CouplingBetweenObjects/ExcludedTypesTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects;
+
+use Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CouplingBetweenObjectsRule>
+ */
+class ExcludedTypesTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        // ExcludedTypesClass has 4 deps (DepA-D). With DepA excluded and maximum=3,
+        // only 3 remain (DepB, DepC, DepD) -> should pass.
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ExcludedTypesClass.php',
+            ],
+            []
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/excluded_types.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CouplingBetweenObjectsRule::class);
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/AttributeCouplingClass.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/AttributeCouplingClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture;
+
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\AnotherAttribute;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepA;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepB;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepC;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\SomeAttribute;
+
+#[SomeAttribute]
+class AttributeCouplingClass
+{
+    #[AnotherAttribute]
+    protected DepA $a;
+
+    public function method(DepB $b): DepC
+    {
+        return new DepC();
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/AttributeNoCouplingClass.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/AttributeNoCouplingClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture;
+
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\AnotherAttribute;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepA;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepB;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepC;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\SomeAttribute;
+
+#[SomeAttribute]
+class AttributeNoCouplingClass
+{
+    #[AnotherAttribute]
+    protected DepA $a;
+
+    public function method(DepB $b): DepC
+    {
+        return new DepC();
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/CustomMaximumHighClass.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/CustomMaximumHighClass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture;
+
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepA;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepB;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepC;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepD;
+
+class CustomMaximumHighClass
+{
+    protected DepA $a;
+
+    protected DepB $b;
+
+    public function method(DepC $c): DepD
+    {
+        return new DepD();
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/CustomMaximumLowClass.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/CustomMaximumLowClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture;
+
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepA;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepB;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepC;
+
+class CustomMaximumLowClass
+{
+    protected DepA $a;
+
+    public function method(DepB $b): DepC
+    {
+        return new DepC();
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/DeduplicationClass.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/DeduplicationClass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture;
+
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepA;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepB;
+
+class DeduplicationClass
+{
+    protected DepA $propA;
+
+    public function method(DepA $a): DepA
+    {
+        $instance = new DepA();
+
+        if ($instance instanceof DepA) {
+            return $instance;
+        }
+
+        return new DepB();
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/AnotherAttribute.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/AnotherAttribute.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+use Attribute;
+
+#[Attribute]
+class AnotherAttribute {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepA.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepA.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepA {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepB.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepB.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepB {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepC.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepC.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepC {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepD.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepD.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepD {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepE.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepE.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepE {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepF.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepF.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepF {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepG.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepG.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepG {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepH.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepH.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepH {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepI.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepI.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepI {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepJ.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepJ.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepJ {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepK.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepK.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepK {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepL.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepL.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepL {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepM.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepM.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepM {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepN.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/DepN.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+class DepN {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/Excluded/ExcludedDepA.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/Excluded/ExcludedDepA.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\Excluded;
+
+class ExcludedDepA {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/Excluded/ExcludedDepB.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/Excluded/ExcludedDepB.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\Excluded;
+
+class ExcludedDepB {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/Deps/SomeAttribute.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/Deps/SomeAttribute.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps;
+
+use Attribute;
+
+#[Attribute]
+class SomeAttribute {}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/ExcludedNamespacesClass.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/ExcludedNamespacesClass.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture;
+
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepA;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepB;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepC;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepD;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\Excluded\ExcludedDepA;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\Excluded\ExcludedDepB;
+
+class ExcludedNamespacesClass
+{
+    protected DepA $a;
+
+    protected ExcludedDepA $excludedA;
+
+    protected ExcludedDepB $excludedB;
+
+    public function method(DepB $b): DepC
+    {
+        return new DepC();
+    }
+
+    public function anotherMethod(DepD $d): void {}
+}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/ExcludedTypesClass.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/ExcludedTypesClass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture;
+
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepA;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepB;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepC;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepD;
+
+class ExcludedTypesClass
+{
+    protected DepA $a;
+
+    protected DepB $b;
+
+    public function method(DepC $c): DepD
+    {
+        return new DepD();
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/HighCouplingClass.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/HighCouplingClass.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture;
+
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepA;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepB;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepC;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepD;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepE;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepF;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepG;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepH;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepI;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepJ;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepK;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepL;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepM;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepN;
+
+class HighCouplingClass
+{
+    protected DepA $propA;
+
+    protected DepB $propB;
+
+    protected DepC $propC;
+
+    public function methodOne(DepD $d): DepE
+    {
+        return new DepE();
+    }
+
+    public function methodTwo(DepF $f): DepG
+    {
+        return new DepG();
+    }
+
+    public function methodThree(): void
+    {
+        $h = new DepH();
+        $i = new DepI();
+
+        if ($h instanceof DepJ) {
+            return;
+        }
+
+        try {
+            DepK::someMethod();
+        } catch (DepL $e) {
+            $m = new DepM();
+        }
+    }
+
+    public function methodFour(DepN $n): void {}
+}

--- a/tests/Rules/CouplingBetweenObjects/Fixture/LowCouplingClass.php
+++ b/tests/Rules/CouplingBetweenObjects/Fixture/LowCouplingClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture;
+
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepA;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepB;
+use Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepC;
+
+class LowCouplingClass
+{
+    protected DepA $propA;
+
+    public function method(DepB $b): DepC
+    {
+        return new DepC();
+    }
+}

--- a/tests/Rules/CouplingBetweenObjects/config/configured_rule.neon
+++ b/tests/Rules/CouplingBetweenObjects/config/configured_rule.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule

--- a/tests/Rules/CouplingBetweenObjects/config/count_attributes_disabled.neon
+++ b/tests/Rules/CouplingBetweenObjects/config/count_attributes_disabled.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule
+
+parameters:
+    meliorstan:
+        coupling_between_objects:
+            maximum: 3
+            count_attributes: false

--- a/tests/Rules/CouplingBetweenObjects/config/custom_maximum.neon
+++ b/tests/Rules/CouplingBetweenObjects/config/custom_maximum.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule
+
+parameters:
+    meliorstan:
+        coupling_between_objects:
+            maximum: 3

--- a/tests/Rules/CouplingBetweenObjects/config/excluded_namespaces.neon
+++ b/tests/Rules/CouplingBetweenObjects/config/excluded_namespaces.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule
+
+parameters:
+    meliorstan:
+        coupling_between_objects:
+            maximum: 3
+            excluded_namespaces:
+                - 'Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\Excluded\'

--- a/tests/Rules/CouplingBetweenObjects/config/excluded_types.neon
+++ b/tests/Rules/CouplingBetweenObjects/config/excluded_types.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CouplingBetweenObjects\CouplingBetweenObjectsRule
+
+parameters:
+    meliorstan:
+        coupling_between_objects:
+            maximum: 3
+            excluded_types:
+                - 'Orrison\MeliorStan\Tests\Rules\CouplingBetweenObjects\Fixture\Deps\DepA'

--- a/tests/Rules/DepthOfInheritance/DefaultOptionsTest.php
+++ b/tests/Rules/DepthOfInheritance/DefaultOptionsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance;
+
+use Orrison\MeliorStan\Rules\DepthOfInheritance\DepthOfInheritanceRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<DepthOfInheritanceRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testNoErrorsUnderDefault(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/Level0.php',
+                __DIR__ . '/Fixture/Level1.php',
+                __DIR__ . '/Fixture/Level2.php',
+                __DIR__ . '/Fixture/Level3.php',
+                __DIR__ . '/Fixture/Level4.php',
+                __DIR__ . '/Fixture/Level5.php',
+                __DIR__ . '/Fixture/Level6.php',
+                __DIR__ . '/Fixture/ShallowChild.php',
+            ],
+            []
+        );
+    }
+
+    public function testErrorsWhenExceedingDefault(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/Level0.php',
+                __DIR__ . '/Fixture/Level1.php',
+                __DIR__ . '/Fixture/Level2.php',
+                __DIR__ . '/Fixture/Level3.php',
+                __DIR__ . '/Fixture/Level4.php',
+                __DIR__ . '/Fixture/Level5.php',
+                __DIR__ . '/Fixture/Level6.php',
+                __DIR__ . '/Fixture/Level7.php',
+            ],
+            [
+                [
+                    sprintf(DepthOfInheritanceRule::ERROR_MESSAGE_TEMPLATE, 'Level7', 7, 6),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/default.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(DepthOfInheritanceRule::class);
+    }
+}

--- a/tests/Rules/DepthOfInheritance/ExcludedNamespacesTest.php
+++ b/tests/Rules/DepthOfInheritance/ExcludedNamespacesTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance;
+
+use Orrison\MeliorStan\Rules\DepthOfInheritance\DepthOfInheritanceRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<DepthOfInheritanceRule>
+ */
+class ExcludedNamespacesTest extends RuleTestCase
+{
+    public function testVendorAncestorsDoNotCount(): void
+    {
+        // UserExtendsVendor extends FrameworkTop -> FrameworkMiddle -> FrameworkBase
+        // Without exclusions: depth = 4 (FrameworkTop, FrameworkMiddle, FrameworkBase = 3 vendor + 0 user ancestors)
+        // Wait — UserExtendsVendor has no user ancestors, just vendor ones.
+        // With vendor namespace excluded: depth = 0 (all ancestors are vendor)
+        // UserExtendsVendorDeep extends UserExtendsVendor -> FrameworkTop -> FrameworkMiddle -> FrameworkBase
+        // With vendor namespace excluded: depth = 1 (only UserExtendsVendor counts)
+        // Maximum is 3, so neither should error.
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/Vendor/FrameworkBase.php',
+                __DIR__ . '/Fixture/Vendor/FrameworkMiddle.php',
+                __DIR__ . '/Fixture/Vendor/FrameworkTop.php',
+                __DIR__ . '/Fixture/UserExtendsVendor.php',
+                __DIR__ . '/Fixture/UserExtendsVendorDeep.php',
+            ],
+            []
+        );
+    }
+
+    public function testWithoutExclusionsWouldError(): void
+    {
+        // This test proves that without exclusions at max 3, Level4 (depth 4) would error.
+        // But we're using excluded-namespaces config which has max 3 AND vendor exclusion.
+        // Level4 has no vendor ancestors, so it still errors.
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/Level0.php',
+                __DIR__ . '/Fixture/Level1.php',
+                __DIR__ . '/Fixture/Level2.php',
+                __DIR__ . '/Fixture/Level3.php',
+                __DIR__ . '/Fixture/Level4.php',
+            ],
+            [
+                [
+                    sprintf(DepthOfInheritanceRule::ERROR_MESSAGE_TEMPLATE, 'Level4', 4, 3),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/excluded-namespaces.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(DepthOfInheritanceRule::class);
+    }
+}

--- a/tests/Rules/DepthOfInheritance/Fixture/IgnoredDeepClass.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/IgnoredDeepClass.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+class IgnoredDeepClass extends Level6 {}

--- a/tests/Rules/DepthOfInheritance/Fixture/Level0.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/Level0.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+class Level0 {}

--- a/tests/Rules/DepthOfInheritance/Fixture/Level1.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/Level1.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+class Level1 extends Level0 {}

--- a/tests/Rules/DepthOfInheritance/Fixture/Level2.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/Level2.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+class Level2 extends Level1 {}

--- a/tests/Rules/DepthOfInheritance/Fixture/Level3.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/Level3.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+class Level3 extends Level2 {}

--- a/tests/Rules/DepthOfInheritance/Fixture/Level4.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/Level4.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+class Level4 extends Level3 {}

--- a/tests/Rules/DepthOfInheritance/Fixture/Level5.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/Level5.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+class Level5 extends Level4 {}

--- a/tests/Rules/DepthOfInheritance/Fixture/Level6.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/Level6.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+class Level6 extends Level5 {}

--- a/tests/Rules/DepthOfInheritance/Fixture/Level7.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/Level7.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+class Level7 extends Level6 {}

--- a/tests/Rules/DepthOfInheritance/Fixture/ShallowChild.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/ShallowChild.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+class ShallowChild extends Level0 {}

--- a/tests/Rules/DepthOfInheritance/Fixture/UserExtendsVendor.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/UserExtendsVendor.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+use Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture\Vendor\FrameworkTop;
+
+class UserExtendsVendor extends FrameworkTop {}

--- a/tests/Rules/DepthOfInheritance/Fixture/UserExtendsVendorDeep.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/UserExtendsVendorDeep.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture;
+
+class UserExtendsVendorDeep extends UserExtendsVendor {}

--- a/tests/Rules/DepthOfInheritance/Fixture/Vendor/FrameworkBase.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/Vendor/FrameworkBase.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture\Vendor;
+
+class FrameworkBase {}

--- a/tests/Rules/DepthOfInheritance/Fixture/Vendor/FrameworkMiddle.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/Vendor/FrameworkMiddle.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture\Vendor;
+
+class FrameworkMiddle extends FrameworkBase {}

--- a/tests/Rules/DepthOfInheritance/Fixture/Vendor/FrameworkTop.php
+++ b/tests/Rules/DepthOfInheritance/Fixture/Vendor/FrameworkTop.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture\Vendor;
+
+class FrameworkTop extends FrameworkMiddle {}

--- a/tests/Rules/DepthOfInheritance/IgnoredClassesTest.php
+++ b/tests/Rules/DepthOfInheritance/IgnoredClassesTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance;
+
+use Orrison\MeliorStan\Rules\DepthOfInheritance\DepthOfInheritanceRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<DepthOfInheritanceRule>
+ */
+class IgnoredClassesTest extends RuleTestCase
+{
+    public function testIgnoredClassDoesNotError(): void
+    {
+        // Level7 has depth 7 and max is 3, but it's in the ignored list so no error.
+        // Level4 has depth 4 and max is 3, NOT ignored so it errors.
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/Level0.php',
+                __DIR__ . '/Fixture/Level1.php',
+                __DIR__ . '/Fixture/Level2.php',
+                __DIR__ . '/Fixture/Level3.php',
+                __DIR__ . '/Fixture/Level4.php',
+                __DIR__ . '/Fixture/Level5.php',
+                __DIR__ . '/Fixture/Level6.php',
+                __DIR__ . '/Fixture/Level7.php',
+            ],
+            [
+                [
+                    sprintf(DepthOfInheritanceRule::ERROR_MESSAGE_TEMPLATE, 'Level4', 4, 3),
+                    5,
+                ],
+                [
+                    sprintf(DepthOfInheritanceRule::ERROR_MESSAGE_TEMPLATE, 'Level5', 5, 3),
+                    5,
+                ],
+                [
+                    sprintf(DepthOfInheritanceRule::ERROR_MESSAGE_TEMPLATE, 'Level6', 6, 3),
+                    5,
+                ],
+                // Level7 is ignored — no error expected
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignored-classes.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(DepthOfInheritanceRule::class);
+    }
+}

--- a/tests/Rules/DepthOfInheritance/MaximumThreeTest.php
+++ b/tests/Rules/DepthOfInheritance/MaximumThreeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DepthOfInheritance;
+
+use Orrison\MeliorStan\Rules\DepthOfInheritance\DepthOfInheritanceRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<DepthOfInheritanceRule>
+ */
+class MaximumThreeTest extends RuleTestCase
+{
+    public function testNoErrorsAtOrBelowThreshold(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/Level0.php',
+                __DIR__ . '/Fixture/Level1.php',
+                __DIR__ . '/Fixture/Level2.php',
+                __DIR__ . '/Fixture/Level3.php',
+                __DIR__ . '/Fixture/ShallowChild.php',
+            ],
+            []
+        );
+    }
+
+    public function testErrorsAboveThreshold(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/Level0.php',
+                __DIR__ . '/Fixture/Level1.php',
+                __DIR__ . '/Fixture/Level2.php',
+                __DIR__ . '/Fixture/Level3.php',
+                __DIR__ . '/Fixture/Level4.php',
+                __DIR__ . '/Fixture/Level5.php',
+                __DIR__ . '/Fixture/Level6.php',
+                __DIR__ . '/Fixture/Level7.php',
+            ],
+            [
+                [
+                    sprintf(DepthOfInheritanceRule::ERROR_MESSAGE_TEMPLATE, 'Level4', 4, 3),
+                    5,
+                ],
+                [
+                    sprintf(DepthOfInheritanceRule::ERROR_MESSAGE_TEMPLATE, 'Level5', 5, 3),
+                    5,
+                ],
+                [
+                    sprintf(DepthOfInheritanceRule::ERROR_MESSAGE_TEMPLATE, 'Level6', 6, 3),
+                    5,
+                ],
+                [
+                    sprintf(DepthOfInheritanceRule::ERROR_MESSAGE_TEMPLATE, 'Level7', 7, 3),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/maximum-three.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(DepthOfInheritanceRule::class);
+    }
+}

--- a/tests/Rules/DepthOfInheritance/config/default.neon
+++ b/tests/Rules/DepthOfInheritance/config/default.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\DepthOfInheritance\DepthOfInheritanceRule

--- a/tests/Rules/DepthOfInheritance/config/excluded-namespaces.neon
+++ b/tests/Rules/DepthOfInheritance/config/excluded-namespaces.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\DepthOfInheritance\DepthOfInheritanceRule
+
+parameters:
+    meliorstan:
+        depth_of_inheritance:
+            maximum: 3
+            excluded_namespaces:
+                - Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture\Vendor\

--- a/tests/Rules/DepthOfInheritance/config/ignored-classes.neon
+++ b/tests/Rules/DepthOfInheritance/config/ignored-classes.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\DepthOfInheritance\DepthOfInheritanceRule
+
+parameters:
+    meliorstan:
+        depth_of_inheritance:
+            maximum: 3
+            ignored_classes:
+                - Orrison\MeliorStan\Tests\Rules\DepthOfInheritance\Fixture\Level7

--- a/tests/Rules/DepthOfInheritance/config/maximum-three.neon
+++ b/tests/Rules/DepthOfInheritance/config/maximum-three.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\DepthOfInheritance\DepthOfInheritanceRule
+
+parameters:
+    meliorstan:
+        depth_of_inheritance:
+            maximum: 3

--- a/tests/Rules/DevelopmentCodeFragment/CustomFunctionsTest.php
+++ b/tests/Rules/DevelopmentCodeFragment/CustomFunctionsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DevelopmentCodeFragment;
+
+use Orrison\MeliorStan\Rules\DevelopmentCodeFragment\DevelopmentCodeFragmentRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<DevelopmentCodeFragmentRule>
+ */
+class CustomFunctionsTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/CustomFunctionsFixture.php'], [
+            [sprintf(DevelopmentCodeFragmentRule::ERROR_MESSAGE_TEMPLATE, 'dump'), 10],
+            [sprintf(DevelopmentCodeFragmentRule::ERROR_MESSAGE_TEMPLATE, 'dd'), 16],
+            [sprintf(DevelopmentCodeFragmentRule::ERROR_MESSAGE_TEMPLATE, 'my_custom_debug'), 22],
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/custom_functions.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(DevelopmentCodeFragmentRule::class);
+    }
+}

--- a/tests/Rules/DevelopmentCodeFragment/DefaultOptionsTest.php
+++ b/tests/Rules/DevelopmentCodeFragment/DefaultOptionsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DevelopmentCodeFragment;
+
+use Orrison\MeliorStan\Rules\DevelopmentCodeFragment\DevelopmentCodeFragmentRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<DevelopmentCodeFragmentRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/ExampleClass.php'], [
+            [sprintf(DevelopmentCodeFragmentRule::ERROR_MESSAGE_TEMPLATE, 'var_dump'), 10],
+            [sprintf(DevelopmentCodeFragmentRule::ERROR_MESSAGE_TEMPLATE, 'print_r'), 16],
+            [sprintf(DevelopmentCodeFragmentRule::ERROR_MESSAGE_TEMPLATE, 'debug_zval_dump'), 22],
+            [sprintf(DevelopmentCodeFragmentRule::ERROR_MESSAGE_TEMPLATE, 'debug_print_backtrace'), 27],
+            [sprintf(DevelopmentCodeFragmentRule::ERROR_MESSAGE_TEMPLATE, 'dd'), 33],
+            [sprintf(DevelopmentCodeFragmentRule::ERROR_MESSAGE_TEMPLATE, 'dump'), 39],
+            [sprintf(DevelopmentCodeFragmentRule::ERROR_MESSAGE_TEMPLATE, 'ray'), 45],
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/default.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(DevelopmentCodeFragmentRule::class);
+    }
+}

--- a/tests/Rules/DevelopmentCodeFragment/Fixture/CustomFunctionsFixture.php
+++ b/tests/Rules/DevelopmentCodeFragment/Fixture/CustomFunctionsFixture.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DevelopmentCodeFragment\Fixture;
+
+class CustomFunctionsFixture
+{
+    public function withDump(): void
+    {
+        $data = ['key' => 'value'];
+        dump($data);
+    }
+
+    public function withDd(): void
+    {
+        $data = ['key' => 'value'];
+        dd($data);
+    }
+
+    public function withCustomDebugFunction(): void
+    {
+        $data = ['key' => 'value'];
+        my_custom_debug($data);
+    }
+
+    public function withVarDumpNowAllowed(): void
+    {
+        $data = ['key' => 'value'];
+        var_dump($data);
+    }
+
+    public function validCode(): void
+    {
+        $data = [1, 2, 3];
+        $count = count($data);
+        echo $count;
+    }
+}

--- a/tests/Rules/DevelopmentCodeFragment/Fixture/ExampleClass.php
+++ b/tests/Rules/DevelopmentCodeFragment/Fixture/ExampleClass.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\DevelopmentCodeFragment\Fixture;
+
+class ExampleClass
+{
+    public function withVarDump(): void
+    {
+        $data = ['key' => 'value'];
+        var_dump($data);
+    }
+
+    public function withPrintR(): void
+    {
+        $data = ['key' => 'value'];
+        print_r($data);
+    }
+
+    public function withDebugZvalDump(): void
+    {
+        $data = 'test';
+        debug_zval_dump($data);
+    }
+
+    public function withDebugPrintBacktrace(): void
+    {
+        debug_print_backtrace();
+    }
+
+    public function withDd(): void
+    {
+        $data = ['key' => 'value'];
+        dd($data);
+    }
+
+    public function withDump(): void
+    {
+        $data = ['key' => 'value'];
+        dump($data);
+    }
+
+    public function withRay(): void
+    {
+        $data = ['key' => 'value'];
+        ray($data);
+    }
+
+    public function validCode(): void
+    {
+        $data = [1, 2, 3];
+        $count = count($data);
+        $mapped = array_map(fn ($item) => $item * 2, $data);
+        echo $count;
+        echo($mapped[0]);
+    }
+}

--- a/tests/Rules/DevelopmentCodeFragment/config/custom_functions.neon
+++ b/tests/Rules/DevelopmentCodeFragment/config/custom_functions.neon
@@ -1,0 +1,13 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\DevelopmentCodeFragment\DevelopmentCodeFragmentRule
+
+parameters:
+    meliorstan:
+        development_code_fragment:
+            unwanted_functions:
+                - dump
+                - dd
+                - my_custom_debug

--- a/tests/Rules/DevelopmentCodeFragment/config/default.neon
+++ b/tests/Rules/DevelopmentCodeFragment/config/default.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\DevelopmentCodeFragment\DevelopmentCodeFragmentRule


### PR DESCRIPTION
This pull request introduces three new rules to the codebase—DevelopmentCodeFragment, CouplingBetweenObjects, and DepthOfInheritance—each with comprehensive configuration options and documentation. It updates the configuration schema, documentation, and service definitions to support these new rules.

**New Rules and Configuration:**

* Added the **DevelopmentCodeFragment** rule to detect calls to development/debug functions (e.g., `var_dump`, `print_r`, etc.), with customizable unwanted function lists. [[1]](diffhunk://#diff-908519a2f73e396b28d3e571d8e66b8c96d2b3c76c06dbc9f08a4cc30b2b97eeR1-R90) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R115-R122) [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R85-R98) [[4]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R168-R178) [[5]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R285-R301)
* Introduced the **CouplingBetweenObjects** rule to flag classes with excessive type dependencies, configurable by maximum allowed, excluded namespaces/types, and whether to count PHP 8 attributes. [[1]](diffhunk://#diff-b4a14d473953be7430da4551b3f58f706c5d2b387f45e2531dafeb44b6506121R1-R203) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R115-R122) [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R85-R98) [[4]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R168-R178) [[5]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R285-R301) [[6]](diffhunk://#diff-d911c321587d09335e7fc67551d362f3a479eae5e62f28ed9a67df6295581e9aR1-R45)
* Added the **DepthOfInheritance** rule to detect classes with overly deep inheritance chains, with options to exclude namespaces or ignore specific classes. [[1]](diffhunk://#diff-394aafb005f4cbd9fcbf466a06524f2201a8100c137eb65afe1ae45b23515082R1-R125) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R115-R122) [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R85-R98) [[4]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R168-R178) [[5]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R285-R301)

**Documentation:**

* Created detailed documentation files for each new rule, including configuration options, usage instructions, and practical examples. [[1]](diffhunk://#diff-908519a2f73e396b28d3e571d8e66b8c96d2b3c76c06dbc9f08a4cc30b2b97eeR1-R90) [[2]](diffhunk://#diff-b4a14d473953be7430da4551b3f58f706c5d2b387f45e2531dafeb44b6506121R1-R203) [[3]](diffhunk://#diff-394aafb005f4cbd9fcbf466a06524f2201a8100c137eb65afe1ae45b23515082R1-R125)

**Configuration and Service Registration:**

* Updated `config/extension.neon` to define parameters and register service factories for the new rules, ensuring they are configurable and integrated with the existing system. [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R85-R98) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R168-R178) [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R285-R301)

These additions enhance code quality checks by enabling detection of debug code, excessive coupling, and deep inheritance, all with customizable settings.

Closes https://github.com/Orrison/MeliorStan/issues/52
Closes https://github.com/Orrison/MeliorStan/issues/53
Closes https://github.com/Orrison/MeliorStan/issues/54