### PR TITLE
feat: add ExcessivePublicCount rule to detect oversized public API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ parameters:
 | **[ForbidGotoStatements](docs/ForbidGotoStatements.md)** | Detects and reports usage of goto statements | Goto Statements |
 | **[CouplingBetweenObjects](docs/CouplingBetweenObjects.md)** | Detects classes with too many type dependencies | Classes, Interfaces, Traits, Enums |
 | **[DepthOfInheritance](docs/DepthOfInheritance.md)** | Detects classes with excessively deep inheritance chains | Classes |
+| **[ExcessivePublicCount](docs/ExcessivePublicCount.md)** | Detects classes with an excessive public API surface (public methods + properties) | Classes, Interfaces, Traits, Enums |
 | **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |
 | **[TooManyMethods](docs/TooManyMethods.md)** | Detects classes with too many methods | Classes, Interfaces, Traits, Enums |

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -96,6 +96,10 @@ parametersSchema:
             excluded_namespaces: arrayOf(string()),
             ignored_classes: arrayOf(string()),
         ]),
+        excessive_public_count: structure([
+            maximum: int(),
+            ignore_pattern: string(),
+        ]),
     ])
 
 # default parameters
@@ -176,6 +180,9 @@ parameters:
             maximum: 6
             excluded_namespaces: []
             ignored_classes: []
+        excessive_public_count:
+            maximum: 45
+            ignore_pattern: '^(get|set|is)'
 
 services:
     -
@@ -299,3 +306,8 @@ services:
             - %meliorstan.depth_of_inheritance.maximum%
             - %meliorstan.depth_of_inheritance.excluded_namespaces%
             - %meliorstan.depth_of_inheritance.ignored_classes%
+    -
+        factory: Orrison\MeliorStan\Rules\ExcessivePublicCount\Config
+        arguments:
+            - %meliorstan.excessive_public_count.maximum%
+            - %meliorstan.excessive_public_count.ignore_pattern%

--- a/docs/ExcessivePublicCount.md
+++ b/docs/ExcessivePublicCount.md
@@ -1,0 +1,139 @@
+# ExcessivePublicCount
+
+This rule reports classes, interfaces, traits, and enums that expose an excessively large public API surface — the sum of their public methods and public properties.
+
+Based on the [PHPMD ExcessivePublicCount](https://phpmd.org/rules/codesize.html#excessivepubliccount) rule, which measures the PHP_Depend **CIS** (Class Interface Size) metric. A large public surface often signals that a class has too many responsibilities and is difficult to test thoroughly.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `maximum`
+- **Type**: `int`
+- **Default**: `45`
+- **Description**: The maximum allowed sum of public methods plus public properties in a class-like structure before triggering an error. Matches PHPMD's default CIS threshold.
+
+### `ignore_pattern`
+- **Type**: `string`
+- **Default**: `^(get|set|is)`
+- **Description**: A regular expression pattern (without delimiters) used to match public method names that should be excluded from the count. By default, getter, setter, and boolean accessor methods are ignored, matching the convention used by the `TooManyMethods` rule. Set to an empty string `''` to count every public method (strict PHPMD parity).
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessivePublicCount\ExcessivePublicCountRule
+
+parameters:
+    meliorstan:
+        excessive_public_count:
+            maximum: 45
+            ignore_pattern: '^(get|set|is)'
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class GodClass
+{
+    public int $propertyOne = 0;
+    public int $propertyTwo = 0;
+    // ... 24 more public properties (26 total)
+
+    public function doOne(): void {}
+    public function doTwo(): void {}
+    // ... 18 more public methods (20 total)
+}
+// ✗ Error: Class "GodClass" has 46 public members (20 methods, 26 properties),
+//          which exceeds the maximum of 45. Consider reducing the public API surface.
+
+class DataTransferObject
+{
+    public function getName(): string { return ''; }
+    public function getEmail(): string { return ''; }
+    // ... 48 more getters (50 total)
+}
+// ✓ Valid — all 50 methods match the default ignore_pattern '^(get|set|is)'
+//          and are excluded from the count.
+
+class ModestClass
+{
+    public int $id = 0;
+    private int $internalState = 0;          // private — not counted
+    protected int $protectedState = 0;       // protected — not counted
+
+    public function process(): void {}
+    private function helper(): void {}       // private — not counted
+}
+// ✓ Valid — only 2 public members; private and protected members are excluded.
+```
+
+### Configuration Examples
+
+#### Strict PHPMD Parity (No Ignore Pattern)
+
+```neon
+parameters:
+    meliorstan:
+        excessive_public_count:
+            ignore_pattern: ''
+```
+
+```php
+<?php
+
+class DataTransferObject
+{
+    public function getOne(): int { return 1; }
+    public function getTwo(): int { return 2; }
+    // ... 44 more getters (46 total)
+}
+// ✗ Error: 46 public members exceeds the maximum of 45.
+//          With ignore_pattern='' getters are counted verbatim.
+```
+
+#### Custom Maximum
+
+```neon
+parameters:
+    meliorstan:
+        excessive_public_count:
+            maximum: 10
+```
+
+```php
+<?php
+
+class Service
+{
+    public int $a = 0, $b = 0, $c = 0, $d = 0, $e = 0, $f = 0;
+
+    public function doOne(): void {}
+    public function doTwo(): void {}
+    public function doThree(): void {}
+    public function doFour(): void {}
+    public function doFive(): void {}
+}
+// ✗ Error: Class "Service" has 11 public members (5 methods, 6 properties),
+//          which exceeds the maximum of 10.
+```
+
+## Important Notes
+
+- The rule applies to classes, interfaces, traits, and enums.
+- Interface methods are always counted — all interface methods are implicitly public.
+- Enum **cases** are not properties and are not counted. Only public methods on enums contribute to the total.
+- Compound property declarations count each declared variable separately: `public $a, $b, $c` adds 3 to the property count.
+- Private and protected members are never counted.
+- The `ignore_pattern` is case-insensitive and pattern delimiters (`/`) are added automatically — only provide the pattern itself.
+- A malformed `ignore_pattern` regex throws an `InvalidArgumentException` naming the offending pattern, matching the behavior of `TooManyMethods`.
+- Methods and properties are counted only from the class-like's own declaration — inherited members are not included.

--- a/docs/ExcessivePublicCount.md
+++ b/docs/ExcessivePublicCount.md
@@ -2,7 +2,7 @@
 
 This rule reports classes, interfaces, traits, and enums that expose an excessively large public API surface — the sum of their public methods and public properties.
 
-Based on the [PHPMD ExcessivePublicCount](https://phpmd.org/rules/codesize.html#excessivepubliccount) rule, which measures the PHP_Depend **CIS** (Class Interface Size) metric. A large public surface often signals that a class has too many responsibilities and is difficult to test thoroughly.
+A large public surface often signals that a class has too many responsibilities and is difficult to test thoroughly. Keeping the count in check encourages smaller, more focused classes.
 
 ## Configuration
 
@@ -11,12 +11,12 @@ This rule supports the following configuration options:
 ### `maximum`
 - **Type**: `int`
 - **Default**: `45`
-- **Description**: The maximum allowed sum of public methods plus public properties in a class-like structure before triggering an error. Matches PHPMD's default CIS threshold.
+- **Description**: The maximum allowed sum of public methods plus public properties in a class-like structure before triggering an error.
 
 ### `ignore_pattern`
 - **Type**: `string`
 - **Default**: `^(get|set|is)`
-- **Description**: A regular expression pattern (without delimiters) used to match public method names that should be excluded from the count. By default, getter, setter, and boolean accessor methods are ignored, matching the convention used by the `TooManyMethods` rule. Set to an empty string `''` to count every public method (strict PHPMD parity).
+- **Description**: A regular expression pattern (without delimiters) used to match public method names that should be excluded from the count. By default, getter, setter, and boolean accessor methods are ignored, matching the convention used by the `TooManyMethods` rule. Set to an empty string `''` to count every public method.
 
 ## Usage
 
@@ -79,7 +79,7 @@ class ModestClass
 
 ### Configuration Examples
 
-#### Strict PHPMD Parity (No Ignore Pattern)
+#### Count Every Public Method (Empty Ignore Pattern)
 
 ```neon
 parameters:

--- a/src/Rules/ExcessivePublicCount/Config.php
+++ b/src/Rules/ExcessivePublicCount/Config.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ExcessivePublicCount;
+
+class Config
+{
+    public function __construct(
+        protected int $maximum = 45,
+        protected string $ignorePattern = '^(get|set|is)',
+    ) {}
+
+    public function getMaximum(): int
+    {
+        return $this->maximum;
+    }
+
+    public function getIgnorePattern(): string
+    {
+        return $this->ignorePattern;
+    }
+}

--- a/src/Rules/ExcessivePublicCount/ExcessivePublicCountRule.php
+++ b/src/Rules/ExcessivePublicCount/ExcessivePublicCountRule.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ExcessivePublicCount;
+
+use InvalidArgumentException;
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Trait_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassLike>
+ */
+class ExcessivePublicCountRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = '%s "%s" has %d public members (%d methods, %d properties), which exceeds the maximum of %d. Consider reducing the public API surface.';
+
+    public function __construct(
+        protected Config $config,
+    ) {}
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassLike::class;
+    }
+
+    /**
+     * @param ClassLike $node
+     *
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        $publicMethods = $this->countPublicMethods($node);
+        $publicProperties = $this->countPublicProperties($node);
+        $total = $publicMethods + $publicProperties;
+
+        if ($total <= $this->config->getMaximum()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    self::ERROR_MESSAGE_TEMPLATE,
+                    $this->getNodeTypeName($node),
+                    $node->name->toString(),
+                    $total,
+                    $publicMethods,
+                    $publicProperties,
+                    $this->config->getMaximum()
+                )
+            )
+                ->identifier('MeliorStan.excessivePublicCount')
+                ->build(),
+        ];
+    }
+
+    protected function countPublicMethods(ClassLike $node): int
+    {
+        $ignorePattern = $this->config->getIgnorePattern();
+        $regex = $ignorePattern === '' ? null : '/' . $ignorePattern . '/i';
+        $isInterface = $node instanceof Interface_;
+        $count = 0;
+
+        foreach ($node->getMethods() as $method) {
+            if (! $isInterface && ! $method->isPublic()) {
+                continue;
+            }
+
+            if ($regex !== null) {
+                $methodName = $method->name->toString();
+                $result = @preg_match($regex, $methodName);
+
+                if ($result === false || preg_last_error() !== PREG_NO_ERROR) {
+                    throw new InvalidArgumentException(
+                        sprintf(
+                            'Invalid regex pattern in ignore_pattern configuration: "%s". Error: %s',
+                            $ignorePattern,
+                            preg_last_error_msg()
+                        )
+                    );
+                }
+
+                if ($result === 1) {
+                    continue;
+                }
+            }
+
+            ++$count;
+        }
+
+        return $count;
+    }
+
+    protected function countPublicProperties(ClassLike $node): int
+    {
+        if ($node instanceof Interface_ || $node instanceof Enum_) {
+            return 0;
+        }
+
+        $count = 0;
+
+        foreach ($node->stmts as $stmt) {
+            if ($stmt instanceof Property && $stmt->isPublic()) {
+                $count += count($stmt->props);
+            }
+        }
+
+        return $count;
+    }
+
+    protected function getNodeTypeName(ClassLike $node): string
+    {
+        if ($node instanceof Class_) {
+            return 'Class';
+        }
+
+        if ($node instanceof Interface_) {
+            return 'Interface';
+        }
+
+        if ($node instanceof Trait_) {
+            return 'Trait';
+        }
+
+        if ($node instanceof Enum_) {
+            return 'Enum';
+        }
+
+        return 'Class';
+    }
+}

--- a/tests/Rules/ExcessivePublicCount/CustomMaximumTest.php
+++ b/tests/Rules/ExcessivePublicCount/CustomMaximumTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount;
+
+use Orrison\MeliorStan\Rules\ExcessivePublicCount\ExcessivePublicCountRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessivePublicCountRule>
+ */
+class CustomMaximumTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/SmallClassExceedingLimit.php',
+                __DIR__ . '/Fixture/ClassWithPublicProperties.php',
+                __DIR__ . '/Fixture/SmallTraitExceedingLimit.php',
+                __DIR__ . '/Fixture/SmallInterfaceExceedingLimit.php',
+                __DIR__ . '/Fixture/SmallEnumExceedingLimit.php',
+                __DIR__ . '/Fixture/ClassWithPrivateAndProtected.php',
+                __DIR__ . '/Fixture/SmallDtoWithGetters.php',
+            ],
+            [
+                [
+                    sprintf(ExcessivePublicCountRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'SmallClassExceedingLimit', 6, 6, 0, 5),
+                    8,
+                ],
+                [
+                    sprintf(ExcessivePublicCountRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassWithPublicProperties', 6, 0, 6, 5),
+                    9,
+                ],
+                [
+                    sprintf(ExcessivePublicCountRule::ERROR_MESSAGE_TEMPLATE, 'Trait', 'SmallTraitExceedingLimit', 6, 6, 0, 5),
+                    8,
+                ],
+                [
+                    sprintf(ExcessivePublicCountRule::ERROR_MESSAGE_TEMPLATE, 'Interface', 'SmallInterfaceExceedingLimit', 6, 6, 0, 5),
+                    8,
+                ],
+                [
+                    sprintf(ExcessivePublicCountRule::ERROR_MESSAGE_TEMPLATE, 'Enum', 'SmallEnumExceedingLimit', 6, 6, 0, 5),
+                    9,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/custom_maximum.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessivePublicCountRule::class);
+    }
+}

--- a/tests/Rules/ExcessivePublicCount/ExcessivePublicCountRuleTest.php
+++ b/tests/Rules/ExcessivePublicCount/ExcessivePublicCountRuleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount;
+
+use Orrison\MeliorStan\Rules\ExcessivePublicCount\ExcessivePublicCountRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessivePublicCountRule>
+ */
+class ExcessivePublicCountRuleTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ClassExceedingLimit.php',
+                __DIR__ . '/Fixture/ClassAtLimit.php',
+                __DIR__ . '/Fixture/DtoWithManyGetters.php',
+                __DIR__ . '/Fixture/ClassWithPrivateAndProtected.php',
+            ],
+            [
+                [
+                    sprintf(ExcessivePublicCountRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassExceedingLimit', 46, 20, 26, 45),
+                    9,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessivePublicCountRule::class);
+    }
+}

--- a/tests/Rules/ExcessivePublicCount/Fixture/ClassAtLimit.php
+++ b/tests/Rules/ExcessivePublicCount/Fixture/ClassAtLimit.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount\Fixture;
+
+/**
+ * 20 public methods (non-ignored names) + 25 public properties = 45 public members.
+ * Exactly at the default maximum of 45 — should not trigger an error.
+ */
+class ClassAtLimit
+{
+    public int $propertyOne = 0;
+
+    public int $propertyTwo = 0;
+
+    public int $propertyThree = 0;
+
+    public int $propertyFour = 0;
+
+    public int $propertyFive = 0;
+
+    public int $propertySix = 0;
+
+    public int $propertySeven = 0;
+
+    public int $propertyEight = 0;
+
+    public int $propertyNine = 0;
+
+    public int $propertyTen = 0;
+
+    public int $propertyEleven = 0;
+
+    public int $propertyTwelve = 0;
+
+    public int $propertyThirteen = 0;
+
+    public int $propertyFourteen = 0;
+
+    public int $propertyFifteen = 0;
+
+    public int $propertySixteen = 0;
+
+    public int $propertySeventeen = 0;
+
+    public int $propertyEighteen = 0;
+
+    public int $propertyNineteen = 0;
+
+    public int $propertyTwenty = 0;
+
+    public int $propertyTwentyOne = 0;
+
+    public int $propertyTwentyTwo = 0;
+
+    public int $propertyTwentyThree = 0;
+
+    public int $propertyTwentyFour = 0;
+
+    public int $propertyTwentyFive = 0;
+
+    public function methodOne(): void {}
+
+    public function methodTwo(): void {}
+
+    public function methodThree(): void {}
+
+    public function methodFour(): void {}
+
+    public function methodFive(): void {}
+
+    public function methodSix(): void {}
+
+    public function methodSeven(): void {}
+
+    public function methodEight(): void {}
+
+    public function methodNine(): void {}
+
+    public function methodTen(): void {}
+
+    public function methodEleven(): void {}
+
+    public function methodTwelve(): void {}
+
+    public function methodThirteen(): void {}
+
+    public function methodFourteen(): void {}
+
+    public function methodFifteen(): void {}
+
+    public function methodSixteen(): void {}
+
+    public function methodSeventeen(): void {}
+
+    public function methodEighteen(): void {}
+
+    public function methodNineteen(): void {}
+
+    public function methodTwenty(): void {}
+}

--- a/tests/Rules/ExcessivePublicCount/Fixture/ClassExceedingLimit.php
+++ b/tests/Rules/ExcessivePublicCount/Fixture/ClassExceedingLimit.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount\Fixture;
+
+/**
+ * 20 public methods (non-ignored names) + 26 public properties = 46 public members.
+ * Exceeds the default maximum of 45.
+ */
+class ClassExceedingLimit
+{
+    public int $propertyOne = 0;
+
+    public int $propertyTwo = 0;
+
+    public int $propertyThree = 0;
+
+    public int $propertyFour = 0;
+
+    public int $propertyFive = 0;
+
+    public int $propertySix = 0;
+
+    public int $propertySeven = 0;
+
+    public int $propertyEight = 0;
+
+    public int $propertyNine = 0;
+
+    public int $propertyTen = 0;
+
+    public int $propertyEleven = 0;
+
+    public int $propertyTwelve = 0;
+
+    public int $propertyThirteen = 0;
+
+    public int $propertyFourteen = 0;
+
+    public int $propertyFifteen = 0;
+
+    public int $propertySixteen = 0;
+
+    public int $propertySeventeen = 0;
+
+    public int $propertyEighteen = 0;
+
+    public int $propertyNineteen = 0;
+
+    public int $propertyTwenty = 0;
+
+    public int $propertyTwentyOne = 0;
+
+    public int $propertyTwentyTwo = 0;
+
+    public int $propertyTwentyThree = 0;
+
+    public int $propertyTwentyFour = 0;
+
+    public int $propertyTwentyFive = 0;
+
+    public int $propertyTwentySix = 0;
+
+    public function methodOne(): void {}
+
+    public function methodTwo(): void {}
+
+    public function methodThree(): void {}
+
+    public function methodFour(): void {}
+
+    public function methodFive(): void {}
+
+    public function methodSix(): void {}
+
+    public function methodSeven(): void {}
+
+    public function methodEight(): void {}
+
+    public function methodNine(): void {}
+
+    public function methodTen(): void {}
+
+    public function methodEleven(): void {}
+
+    public function methodTwelve(): void {}
+
+    public function methodThirteen(): void {}
+
+    public function methodFourteen(): void {}
+
+    public function methodFifteen(): void {}
+
+    public function methodSixteen(): void {}
+
+    public function methodSeventeen(): void {}
+
+    public function methodEighteen(): void {}
+
+    public function methodNineteen(): void {}
+
+    public function methodTwenty(): void {}
+}

--- a/tests/Rules/ExcessivePublicCount/Fixture/ClassWithPrivateAndProtected.php
+++ b/tests/Rules/ExcessivePublicCount/Fixture/ClassWithPrivateAndProtected.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount\Fixture;
+
+/**
+ * Many private/protected members that must NOT be counted toward the public
+ * count. Only 3 public members total, so this must pass under every default-
+ * threshold test.
+ */
+class ClassWithPrivateAndProtected
+{
+    public int $publicOne = 0;
+
+    protected int $protectedOne = 0;
+
+    protected int $protectedTwo = 0;
+
+    protected int $protectedThree = 0;
+
+    protected int $protectedFour = 0;
+
+    private int $privateOne = 0;
+
+    private int $privateTwo = 0;
+
+    private int $privateThree = 0;
+
+    private int $privateFour = 0;
+
+    private int $privateFive = 0;
+
+    public function publicMethod(): void {}
+
+    public function anotherPublicMethod(): void {}
+
+    protected function protectedMethod(): void {}
+
+    protected function anotherProtectedMethod(): void {}
+
+    private function privateMethod(): void {}
+
+    private function anotherPrivateMethod(): void {}
+}

--- a/tests/Rules/ExcessivePublicCount/Fixture/ClassWithPublicProperties.php
+++ b/tests/Rules/ExcessivePublicCount/Fixture/ClassWithPublicProperties.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount\Fixture;
+
+/**
+ * 6 public properties and no methods — exceeds a custom maximum of 5.
+ * Verifies that public properties contribute to the member count.
+ */
+class ClassWithPublicProperties
+{
+    public int $a = 0;
+
+    public int $b = 0;
+
+    public int $c = 0;
+
+    public int $d = 0;
+
+    public int $e = 0;
+
+    public int $f = 0;
+}

--- a/tests/Rules/ExcessivePublicCount/Fixture/DtoWithManyGetters.php
+++ b/tests/Rules/ExcessivePublicCount/Fixture/DtoWithManyGetters.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount\Fixture;
+
+/**
+ * 50 getter methods — all ignored by the default ignore_pattern '^(get|set|is)'.
+ * With the default config, this DTO should pass.
+ * When ignore_pattern is set to '', every getter is counted and the class errors.
+ */
+class DtoWithManyGetters
+{
+    public function getOne(): int
+    {
+        return 1;
+    }
+
+    public function getTwo(): int
+    {
+        return 2;
+    }
+
+    public function getThree(): int
+    {
+        return 3;
+    }
+
+    public function getFour(): int
+    {
+        return 4;
+    }
+
+    public function getFive(): int
+    {
+        return 5;
+    }
+
+    public function getSix(): int
+    {
+        return 6;
+    }
+
+    public function getSeven(): int
+    {
+        return 7;
+    }
+
+    public function getEight(): int
+    {
+        return 8;
+    }
+
+    public function getNine(): int
+    {
+        return 9;
+    }
+
+    public function getTen(): int
+    {
+        return 10;
+    }
+
+    public function getEleven(): int
+    {
+        return 11;
+    }
+
+    public function getTwelve(): int
+    {
+        return 12;
+    }
+
+    public function getThirteen(): int
+    {
+        return 13;
+    }
+
+    public function getFourteen(): int
+    {
+        return 14;
+    }
+
+    public function getFifteen(): int
+    {
+        return 15;
+    }
+
+    public function getSixteen(): int
+    {
+        return 16;
+    }
+
+    public function getSeventeen(): int
+    {
+        return 17;
+    }
+
+    public function getEighteen(): int
+    {
+        return 18;
+    }
+
+    public function getNineteen(): int
+    {
+        return 19;
+    }
+
+    public function getTwenty(): int
+    {
+        return 20;
+    }
+
+    public function getTwentyOne(): int
+    {
+        return 21;
+    }
+
+    public function getTwentyTwo(): int
+    {
+        return 22;
+    }
+
+    public function getTwentyThree(): int
+    {
+        return 23;
+    }
+
+    public function getTwentyFour(): int
+    {
+        return 24;
+    }
+
+    public function getTwentyFive(): int
+    {
+        return 25;
+    }
+
+    public function getTwentySix(): int
+    {
+        return 26;
+    }
+
+    public function getTwentySeven(): int
+    {
+        return 27;
+    }
+
+    public function getTwentyEight(): int
+    {
+        return 28;
+    }
+
+    public function getTwentyNine(): int
+    {
+        return 29;
+    }
+
+    public function getThirty(): int
+    {
+        return 30;
+    }
+
+    public function getThirtyOne(): int
+    {
+        return 31;
+    }
+
+    public function getThirtyTwo(): int
+    {
+        return 32;
+    }
+
+    public function getThirtyThree(): int
+    {
+        return 33;
+    }
+
+    public function getThirtyFour(): int
+    {
+        return 34;
+    }
+
+    public function getThirtyFive(): int
+    {
+        return 35;
+    }
+
+    public function getThirtySix(): int
+    {
+        return 36;
+    }
+
+    public function getThirtySeven(): int
+    {
+        return 37;
+    }
+
+    public function getThirtyEight(): int
+    {
+        return 38;
+    }
+
+    public function getThirtyNine(): int
+    {
+        return 39;
+    }
+
+    public function getForty(): int
+    {
+        return 40;
+    }
+
+    public function getFortyOne(): int
+    {
+        return 41;
+    }
+
+    public function getFortyTwo(): int
+    {
+        return 42;
+    }
+
+    public function getFortyThree(): int
+    {
+        return 43;
+    }
+
+    public function getFortyFour(): int
+    {
+        return 44;
+    }
+
+    public function getFortyFive(): int
+    {
+        return 45;
+    }
+
+    public function getFortySix(): int
+    {
+        return 46;
+    }
+
+    public function getFortySeven(): int
+    {
+        return 47;
+    }
+
+    public function getFortyEight(): int
+    {
+        return 48;
+    }
+
+    public function getFortyNine(): int
+    {
+        return 49;
+    }
+
+    public function getFifty(): int
+    {
+        return 50;
+    }
+}

--- a/tests/Rules/ExcessivePublicCount/Fixture/SmallClassExceedingLimit.php
+++ b/tests/Rules/ExcessivePublicCount/Fixture/SmallClassExceedingLimit.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount\Fixture;
+
+/**
+ * 6 public methods with non-ignored names. Exceeds a custom maximum of 5.
+ */
+class SmallClassExceedingLimit
+{
+    public function doOne(): void {}
+
+    public function doTwo(): void {}
+
+    public function doThree(): void {}
+
+    public function doFour(): void {}
+
+    public function doFive(): void {}
+
+    public function doSix(): void {}
+}

--- a/tests/Rules/ExcessivePublicCount/Fixture/SmallDtoWithGetters.php
+++ b/tests/Rules/ExcessivePublicCount/Fixture/SmallDtoWithGetters.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount\Fixture;
+
+/**
+ * 6 getter methods. With the default ignore_pattern they all get skipped.
+ * With ignore_pattern='' they are all counted and exceed a custom maximum of 5.
+ */
+class SmallDtoWithGetters
+{
+    public function getOne(): int
+    {
+        return 1;
+    }
+
+    public function getTwo(): int
+    {
+        return 2;
+    }
+
+    public function getThree(): int
+    {
+        return 3;
+    }
+
+    public function getFour(): int
+    {
+        return 4;
+    }
+
+    public function getFive(): int
+    {
+        return 5;
+    }
+
+    public function getSix(): int
+    {
+        return 6;
+    }
+}

--- a/tests/Rules/ExcessivePublicCount/Fixture/SmallEnumExceedingLimit.php
+++ b/tests/Rules/ExcessivePublicCount/Fixture/SmallEnumExceedingLimit.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount\Fixture;
+
+/**
+ * 6 public methods and 3 cases. Cases must NOT be counted toward the public
+ * member total — only the methods count, so this exceeds maximum 5.
+ */
+enum SmallEnumExceedingLimit
+{
+    case FIRST;
+    case SECOND;
+    case THIRD;
+
+    public function enumOne(): void {}
+
+    public function enumTwo(): void {}
+
+    public function enumThree(): void {}
+
+    public function enumFour(): void {}
+
+    public function enumFive(): void {}
+
+    public function enumSix(): void {}
+}

--- a/tests/Rules/ExcessivePublicCount/Fixture/SmallInterfaceExceedingLimit.php
+++ b/tests/Rules/ExcessivePublicCount/Fixture/SmallInterfaceExceedingLimit.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount\Fixture;
+
+/**
+ * 6 interface methods (implicitly public) — exceeds a custom maximum of 5.
+ */
+interface SmallInterfaceExceedingLimit
+{
+    public function one(): void;
+
+    public function two(): void;
+
+    public function three(): void;
+
+    public function four(): void;
+
+    public function five(): void;
+
+    public function six(): void;
+}

--- a/tests/Rules/ExcessivePublicCount/Fixture/SmallTraitExceedingLimit.php
+++ b/tests/Rules/ExcessivePublicCount/Fixture/SmallTraitExceedingLimit.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount\Fixture;
+
+/**
+ * 6 public methods in a trait — exceeds a custom maximum of 5.
+ */
+trait SmallTraitExceedingLimit
+{
+    public function traitOne(): void {}
+
+    public function traitTwo(): void {}
+
+    public function traitThree(): void {}
+
+    public function traitFour(): void {}
+
+    public function traitFive(): void {}
+
+    public function traitSix(): void {}
+}

--- a/tests/Rules/ExcessivePublicCount/NoIgnorePatternTest.php
+++ b/tests/Rules/ExcessivePublicCount/NoIgnorePatternTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessivePublicCount;
+
+use Orrison\MeliorStan\Rules\ExcessivePublicCount\ExcessivePublicCountRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessivePublicCountRule>
+ */
+class NoIgnorePatternTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/SmallDtoWithGetters.php',
+            ],
+            [
+                [
+                    sprintf(ExcessivePublicCountRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'SmallDtoWithGetters', 6, 6, 0, 5),
+                    9,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/no_ignore_pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessivePublicCountRule::class);
+    }
+}

--- a/tests/Rules/ExcessivePublicCount/config/configured_rule.neon
+++ b/tests/Rules/ExcessivePublicCount/config/configured_rule.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessivePublicCount\ExcessivePublicCountRule

--- a/tests/Rules/ExcessivePublicCount/config/custom_maximum.neon
+++ b/tests/Rules/ExcessivePublicCount/config/custom_maximum.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessivePublicCount\ExcessivePublicCountRule
+
+parameters:
+    meliorstan:
+        excessive_public_count:
+            maximum: 5

--- a/tests/Rules/ExcessivePublicCount/config/no_ignore_pattern.neon
+++ b/tests/Rules/ExcessivePublicCount/config/no_ignore_pattern.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessivePublicCount\ExcessivePublicCountRule
+
+parameters:
+    meliorstan:
+        excessive_public_count:
+            maximum: 5
+            ignore_pattern: ''


### PR DESCRIPTION
Replicates PHPMD's ExcessivePublicCount (CIS metric) — counts a class-like's
public methods + public properties and errors when the total exceeds a
configurable maximum. Defaults to PHPMD's threshold of 45 and shares
TooManyMethods' ignore_pattern convention so getters/setters don't dominate
the count. Applies to classes, traits, interfaces, and enums.

Closes https://github.com/Orrison/MeliorStan/issues/42