### PR TITLE
Create the StaticAccessRule and tests for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ parameters:
 | **[ExcessivePublicCount](docs/ExcessivePublicCount.md)** | Detects classes with an excessive public API surface (public methods + properties) | Classes, Interfaces, Traits, Enums |
 | **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |
+| **[StaticAccess](docs/StaticAccess.md)** | Detects static method calls and optionally static property access that create tight coupling | Static Access |
 | **[TooManyMethods](docs/TooManyMethods.md)** | Detects classes with too many methods | Classes, Interfaces, Traits, Enums |
 
 ### Already Covered by PHPStan

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -100,6 +100,12 @@ parametersSchema:
             maximum: int(),
             ignore_pattern: string(),
         ]),
+        static_access: structure([
+            exceptions: arrayOf(string()),
+            method_ignore_pattern: string(),
+            property_ignore_pattern: string(),
+            check_static_property_access: bool(),
+        ]),
     ])
 
 # default parameters
@@ -183,6 +189,11 @@ parameters:
         excessive_public_count:
             maximum: 45
             ignore_pattern: '^(get|set|is)'
+        static_access:
+            exceptions: []
+            method_ignore_pattern: ''
+            property_ignore_pattern: ''
+            check_static_property_access: false
 
 services:
     -
@@ -311,3 +322,10 @@ services:
         arguments:
             - %meliorstan.excessive_public_count.maximum%
             - %meliorstan.excessive_public_count.ignore_pattern%
+    -
+        factory: Orrison\MeliorStan\Rules\StaticAccess\Config
+        arguments:
+            - %meliorstan.static_access.exceptions%
+            - %meliorstan.static_access.method_ignore_pattern%
+            - %meliorstan.static_access.property_ignore_pattern%
+            - %meliorstan.static_access.check_static_property_access%

--- a/docs/StaticAccess.md
+++ b/docs/StaticAccess.md
@@ -1,6 +1,6 @@
 # StaticAccess
 
-Static access causes unexchangeable dependencies to other classes and leads to hard to test code.
+Static access creates hard-to-replace dependencies on other classes and leads to hard-to-test code.
 
 This rule detects static method calls (e.g., `SomeClass::doSomething()`) and optionally static property access (e.g., `SomeClass::$value`). Static access creates tight coupling between classes, making it difficult to substitute dependencies during testing or when requirements change. The recommended approach is to inject dependencies through constructors instead.
 
@@ -95,6 +95,8 @@ parameters:
 
 ```php
 <?php
+
+use Illuminate\Support\Facades\Cache;
 
 class UserService
 {

--- a/docs/StaticAccess.md
+++ b/docs/StaticAccess.md
@@ -1,0 +1,169 @@
+# StaticAccess
+
+Static access causes unexchangeable dependencies to other classes and leads to hard to test code.
+
+This rule detects static method calls (e.g., `SomeClass::doSomething()`) and optionally static property access (e.g., `SomeClass::$value`). Static access creates tight coupling between classes, making it difficult to substitute dependencies during testing or when requirements change. The recommended approach is to inject dependencies through constructors instead.
+
+Calls to `self::`, `static::`, and `parent::` are always excluded since they reference the current class hierarchy and are not external dependencies.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `exceptions`
+- **Type**: `array<string>`
+- **Default**: `[]`
+- **Description**: A list of fully-qualified class names to exclude from this rule. Supports wildcard patterns using `*` (e.g., `Illuminate\Support\Facades\*` to exclude all Laravel facades). Class names should not include a leading backslash.
+
+### `method_ignore_pattern`
+- **Type**: `string`
+- **Default**: `''`
+- **Description**: A regular expression pattern to match method names that should be ignored. This is useful for allowing factory methods while still flagging other static access.
+
+```php
+// Example: '/^(create|make|from|of)/' to ignore common factory method patterns
+```
+
+### `property_ignore_pattern`
+- **Type**: `string`
+- **Default**: `''`
+- **Description**: A regular expression pattern to match property names that should be ignored. Only applies when `check_static_property_access` is enabled.
+
+```php
+// Example: '/^(config|default)/' to ignore configuration-style static properties
+```
+
+### `check_static_property_access`
+- **Type**: `bool`
+- **Default**: `false`
+- **Description**: When enabled, also flags static property access (`ClassName::$property`) in addition to static method calls.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule
+
+parameters:
+    meliorstan:
+        static_access:
+            exceptions: []
+            method_ignore_pattern: ''
+            property_ignore_pattern: ''
+            check_static_property_access: false
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class UserService
+{
+    public static function helper(): void {}
+
+    public function process(): void
+    {
+        Logger::info('processing');       // ✗ Error: Avoid using static access to "Logger::info()". Use dependency injection instead.
+        Cache::get('key');                // ✗ Error: Avoid using static access to "Cache::get()". Use dependency injection instead.
+        self::helper();                   // ✓ Valid — self reference
+        static::helper();                // ✓ Valid — static reference
+        parent::process();               // ✓ Valid — parent reference
+    }
+}
+```
+
+### Configuration Examples
+
+#### Exceptions
+
+```neon
+parameters:
+    meliorstan:
+        static_access:
+            exceptions:
+                - App\Helpers\StringHelper
+                - Illuminate\Support\Facades\*
+```
+
+```php
+<?php
+
+class UserService
+{
+    public function process(): void
+    {
+        StringHelper::trim('value');       // ✓ Now valid — exact match exception
+        Cache::get('key');                 // ✓ Now valid — wildcard match on Illuminate\Support\Facades\*
+        Logger::info('processing');        // ✗ Error — not in exceptions list
+    }
+}
+```
+
+#### Method Ignore Pattern
+
+```neon
+parameters:
+    meliorstan:
+        static_access:
+            method_ignore_pattern: '/^(create|make|from)/'
+```
+
+```php
+<?php
+
+class OrderService
+{
+    public function process(): void
+    {
+        Order::create($data);             // ✓ Now valid — method name matches pattern
+        Collection::make([1, 2, 3]);      // ✓ Now valid — method name matches pattern
+        Carbon::fromTimestamp(time());     // ✓ Now valid — method name matches pattern
+        Logger::info('processing');        // ✗ Error — method name does not match pattern
+    }
+}
+```
+
+#### Check Static Property Access with Property Ignore Pattern
+
+```neon
+parameters:
+    meliorstan:
+        static_access:
+            check_static_property_access: true
+            property_ignore_pattern: '/^(config|default)/'
+```
+
+```php
+<?php
+
+class ReportService
+{
+    protected static string $name = 'report';
+
+    public function process(): void
+    {
+        Config::$debug;                   // ✗ Error: Avoid using static access to "Config::$debug". Use dependency injection instead.
+        Settings::$configPath;            // ✓ Now valid — property name matches pattern
+        Settings::$defaultTimeout;        // ✓ Now valid — property name matches pattern
+        Logger::info('processing');        // ✗ Error: Avoid using static access to "Logger::info()". Use dependency injection instead.
+        self::$name;                      // ✓ Valid — self reference
+        static::$name;                    // ✓ Valid — static reference
+    }
+}
+```
+
+## Important Notes
+
+- Class names in the `exceptions` configuration should be fully-qualified without a leading backslash (e.g., `App\Services\MyService`, not `\App\Services\MyService`).
+- The `*` wildcard in exceptions matches any characters, making it easy to exclude entire namespaces.
+- Dynamic static calls (e.g., `$className::method()`) are not detected since the class name cannot be determined from the AST alone.
+- The `method_ignore_pattern` only applies to static method calls, and `property_ignore_pattern` only applies to static property access.
+- The `property_ignore_pattern` has no effect unless `check_static_property_access` is enabled.

--- a/src/Rules/StaticAccess/Config.php
+++ b/src/Rules/StaticAccess/Config.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\StaticAccess;
+
+class Config
+{
+    /**
+     * @param array<string> $exceptions List of fully-qualified class names or wildcard patterns to exclude from static access checks.
+     * @param string $methodIgnorePattern Regular expression pattern for method names to ignore.
+     * @param string $propertyIgnorePattern Regular expression pattern for property names to ignore.
+     * @param bool $checkStaticPropertyAccess Whether to also flag static property access.
+     */
+    public function __construct(
+        protected array $exceptions,
+        protected string $methodIgnorePattern,
+        protected string $propertyIgnorePattern,
+        protected bool $checkStaticPropertyAccess,
+    ) {}
+
+    /**
+     * @return array<string>
+     */
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+
+    public function getMethodIgnorePattern(): string
+    {
+        return $this->methodIgnorePattern;
+    }
+
+    public function getPropertyIgnorePattern(): string
+    {
+        return $this->propertyIgnorePattern;
+    }
+
+    public function getCheckStaticPropertyAccess(): bool
+    {
+        return $this->checkStaticPropertyAccess;
+    }
+
+    public function isExcepted(string $className): bool
+    {
+        foreach ($this->exceptions as $exception) {
+            if (fnmatch($exception, $className, FNM_NOESCAPE)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rules/StaticAccess/StaticAccessRule.php
+++ b/src/Rules/StaticAccess/StaticAccessRule.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\StaticAccess;
+
+use InvalidArgumentException;
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Node>
+ */
+class StaticAccessRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = 'Avoid using static access to "%s::%s()". Use dependency injection instead.';
+
+    public const string ERROR_MESSAGE_TEMPLATE_PROPERTY = 'Avoid using static access to "%s::$%s". Use dependency injection instead.';
+
+    /** @var array<string, true> */
+    protected const array SELF_REFERENCES = [
+        'self' => true,
+        'static' => true,
+        'parent' => true,
+    ];
+
+    public function __construct(
+        protected Config $config,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return Node::class;
+    }
+
+    /**
+     * @return list<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node instanceof StaticCall) {
+            return $this->processStaticCall($node);
+        }
+
+        if ($node instanceof StaticPropertyFetch && $this->config->getCheckStaticPropertyAccess()) {
+            return $this->processStaticPropertyFetch($node);
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<RuleError>
+     */
+    protected function processStaticCall(StaticCall $node): array
+    {
+        if (! $node->class instanceof Name) {
+            return [];
+        }
+
+        $className = $node->class->toString();
+
+        if ($this->isSelfReference($className)) {
+            return [];
+        }
+
+        if ($this->config->isExcepted($className)) {
+            return [];
+        }
+
+        if ($node->name instanceof Identifier) {
+            $methodName = $node->name->toString();
+
+            if ($this->shouldIgnoreByPattern($methodName, $this->config->getMethodIgnorePattern())) {
+                return [];
+            }
+
+            return [
+                RuleErrorBuilder::message(
+                    sprintf(self::ERROR_MESSAGE_TEMPLATE, $className, $methodName)
+                )
+                    ->identifier('MeliorStan.staticAccess')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<RuleError>
+     */
+    protected function processStaticPropertyFetch(StaticPropertyFetch $node): array
+    {
+        if (! $node->class instanceof Name) {
+            return [];
+        }
+
+        $className = $node->class->toString();
+
+        if ($this->isSelfReference($className)) {
+            return [];
+        }
+
+        if ($this->config->isExcepted($className)) {
+            return [];
+        }
+
+        if ($node->name instanceof Identifier) {
+            $propertyName = $node->name->toString();
+
+            if ($this->shouldIgnoreByPattern($propertyName, $this->config->getPropertyIgnorePattern())) {
+                return [];
+            }
+
+            return [
+                RuleErrorBuilder::message(
+                    sprintf(self::ERROR_MESSAGE_TEMPLATE_PROPERTY, $className, $propertyName)
+                )
+                    ->identifier('MeliorStan.staticAccess')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+
+    protected function isSelfReference(string $className): bool
+    {
+        return isset(self::SELF_REFERENCES[strtolower($className)]);
+    }
+
+    protected function shouldIgnoreByPattern(string $name, string $pattern): bool
+    {
+        if ($pattern === '') {
+            return false;
+        }
+
+        $result = @preg_match($pattern, $name);
+
+        if ($result === false || preg_last_error() !== PREG_NO_ERROR) {
+            $error = preg_last_error_msg();
+
+            throw new InvalidArgumentException(
+                sprintf('Invalid regex pattern in ignore_pattern configuration: "%s". Error: %s', $pattern, $error)
+            );
+        }
+
+        return $result === 1;
+    }
+}

--- a/src/Rules/StaticAccess/StaticAccessRule.php
+++ b/src/Rules/StaticAccess/StaticAccessRule.php
@@ -76,7 +76,7 @@ class StaticAccessRule implements Rule
         if ($node->name instanceof Identifier) {
             $methodName = $node->name->toString();
 
-            if ($this->shouldIgnoreByPattern($methodName, $this->config->getMethodIgnorePattern())) {
+            if ($this->shouldIgnoreByPattern($methodName, $this->config->getMethodIgnorePattern(), 'method_ignore_pattern')) {
                 return [];
             }
 
@@ -114,7 +114,7 @@ class StaticAccessRule implements Rule
         if ($node->name instanceof Identifier) {
             $propertyName = $node->name->toString();
 
-            if ($this->shouldIgnoreByPattern($propertyName, $this->config->getPropertyIgnorePattern())) {
+            if ($this->shouldIgnoreByPattern($propertyName, $this->config->getPropertyIgnorePattern(), 'property_ignore_pattern')) {
                 return [];
             }
 
@@ -135,7 +135,7 @@ class StaticAccessRule implements Rule
         return isset(self::SELF_REFERENCES[strtolower($className)]);
     }
 
-    protected function shouldIgnoreByPattern(string $name, string $pattern): bool
+    protected function shouldIgnoreByPattern(string $name, string $pattern, string $configKey): bool
     {
         if ($pattern === '') {
             return false;
@@ -147,7 +147,7 @@ class StaticAccessRule implements Rule
             $error = preg_last_error_msg();
 
             throw new InvalidArgumentException(
-                sprintf('Invalid regex pattern in ignore_pattern configuration: "%s". Error: %s', $pattern, $error)
+                sprintf('Invalid regex pattern in %s configuration: "%s". Error: %s', $configKey, $pattern, $error)
             );
         }
 

--- a/tests/Rules/StaticAccess/CheckStaticPropertyAccessTest.php
+++ b/tests/Rules/StaticAccess/CheckStaticPropertyAccessTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess;
+
+use Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<StaticAccessRule>
+ */
+class CheckStaticPropertyAccessTest extends RuleTestCase
+{
+    public function testStaticPropertyAccessExample(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/StaticPropertyAccessExample.php',
+            __DIR__ . '/Fixture/SomeService.php',
+            __DIR__ . '/Fixture/AnotherService.php',
+        ], [
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\SomeService', 'process'), 11],
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE_PROPERTY, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\SomeService', 'value'), 12],
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE_PROPERTY, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\AnotherService', 'count'), 13],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/check-static-property-access.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(StaticAccessRule::class);
+    }
+}

--- a/tests/Rules/StaticAccess/DefaultTest.php
+++ b/tests/Rules/StaticAccess/DefaultTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess;
+
+use Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<StaticAccessRule>
+ */
+class DefaultTest extends RuleTestCase
+{
+    public function testDefaultExample(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/DefaultExample.php',
+            __DIR__ . '/Fixture/BaseExample.php',
+            __DIR__ . '/Fixture/SomeService.php',
+            __DIR__ . '/Fixture/AnotherService.php',
+        ], [
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\SomeService', 'process'), 11],
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\AnotherService', 'handle'), 12],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/default.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(StaticAccessRule::class);
+    }
+}

--- a/tests/Rules/StaticAccess/ExceptionsTest.php
+++ b/tests/Rules/StaticAccess/ExceptionsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess;
+
+use Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<StaticAccessRule>
+ */
+class ExceptionsTest extends RuleTestCase
+{
+    public function testExceptionsExample(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/ExceptionsExample.php',
+            __DIR__ . '/Fixture/AllowedService.php',
+            __DIR__ . '/Fixture/SomeService.php',
+            __DIR__ . '/Fixture/AnotherService.php',
+        ], [
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\SomeService', 'process'), 10],
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\AnotherService', 'handle'), 11],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/exceptions.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(StaticAccessRule::class);
+    }
+}

--- a/tests/Rules/StaticAccess/ExceptionsWildcardTest.php
+++ b/tests/Rules/StaticAccess/ExceptionsWildcardTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess;
+
+use Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<StaticAccessRule>
+ */
+class ExceptionsWildcardTest extends RuleTestCase
+{
+    public function testExceptionsWildcardExample(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/ExceptionsWildcardExample.php',
+            __DIR__ . '/Fixture/Helpers/StringHelper.php',
+            __DIR__ . '/Fixture/Helpers/ArrayHelper.php',
+            __DIR__ . '/Fixture/SomeService.php',
+        ], [
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\SomeService', 'process'), 14],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/exceptions-wildcard.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(StaticAccessRule::class);
+    }
+}

--- a/tests/Rules/StaticAccess/Fixture/AllowedService.php
+++ b/tests/Rules/StaticAccess/Fixture/AllowedService.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture;
+
+class AllowedService
+{
+    public static function allowed(): void {}
+}

--- a/tests/Rules/StaticAccess/Fixture/AnotherService.php
+++ b/tests/Rules/StaticAccess/Fixture/AnotherService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture;
+
+class AnotherService
+{
+    public static int $count = 0;
+
+    public static string $configValue = 'test';
+
+    public static int $defaultTimeout = 30;
+
+    public static function handle(): void {}
+}

--- a/tests/Rules/StaticAccess/Fixture/BaseExample.php
+++ b/tests/Rules/StaticAccess/Fixture/BaseExample.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture;
+
+class BaseExample
+{
+    public static function baseMethod(): void {}
+}

--- a/tests/Rules/StaticAccess/Fixture/DefaultExample.php
+++ b/tests/Rules/StaticAccess/Fixture/DefaultExample.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture;
+
+class DefaultExample extends BaseExample
+{
+    public static function helper(): void {}
+
+    public function test(): void
+    {
+        SomeService::process();
+        AnotherService::handle();
+        self::helper();
+        static::helper();
+        parent::baseMethod();
+    }
+}

--- a/tests/Rules/StaticAccess/Fixture/ExceptionsExample.php
+++ b/tests/Rules/StaticAccess/Fixture/ExceptionsExample.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture;
+
+class ExceptionsExample
+{
+    public function test(): void
+    {
+        AllowedService::allowed();
+        SomeService::process();
+        AnotherService::handle();
+    }
+}

--- a/tests/Rules/StaticAccess/Fixture/ExceptionsWildcardExample.php
+++ b/tests/Rules/StaticAccess/Fixture/ExceptionsWildcardExample.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture;
+
+use Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\Helpers\ArrayHelper;
+use Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\Helpers\StringHelper;
+
+class ExceptionsWildcardExample
+{
+    public function test(): void
+    {
+        StringHelper::trim('hello');
+        ArrayHelper::flatten([]);
+        SomeService::process();
+    }
+}

--- a/tests/Rules/StaticAccess/Fixture/Helpers/ArrayHelper.php
+++ b/tests/Rules/StaticAccess/Fixture/Helpers/ArrayHelper.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\Helpers;
+
+class ArrayHelper
+{
+    public static function flatten(array $items): array
+    {
+        return $items;
+    }
+}

--- a/tests/Rules/StaticAccess/Fixture/Helpers/StringHelper.php
+++ b/tests/Rules/StaticAccess/Fixture/Helpers/StringHelper.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\Helpers;
+
+class StringHelper
+{
+    public static function trim(string $value): string
+    {
+        return trim($value);
+    }
+}

--- a/tests/Rules/StaticAccess/Fixture/IgnorePatternExample.php
+++ b/tests/Rules/StaticAccess/Fixture/IgnorePatternExample.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture;
+
+class IgnorePatternExample
+{
+    public function test(): void
+    {
+        SomeService::createInstance();
+        SomeService::fromArray([]);
+        SomeService::make();
+        SomeService::process();
+        AnotherService::handle();
+    }
+
+    public static function createInstance(): static
+    {
+        return new static();
+    }
+
+    public static function fromArray(array $data): static
+    {
+        return new static();
+    }
+
+    public static function make(): static
+    {
+        return new static();
+    }
+}

--- a/tests/Rules/StaticAccess/Fixture/IgnorePatternExample.php
+++ b/tests/Rules/StaticAccess/Fixture/IgnorePatternExample.php
@@ -6,9 +6,9 @@ class IgnorePatternExample
 {
     public function test(): void
     {
-        SomeService::createInstance();
-        SomeService::fromArray([]);
-        SomeService::make();
+        IgnorePatternExample::createInstance();
+        IgnorePatternExample::fromArray([]);
+        IgnorePatternExample::make();
         SomeService::process();
         AnotherService::handle();
     }

--- a/tests/Rules/StaticAccess/Fixture/PropertyIgnorePatternExample.php
+++ b/tests/Rules/StaticAccess/Fixture/PropertyIgnorePatternExample.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture;
+
+class PropertyIgnorePatternExample
+{
+    public function test(): void
+    {
+        SomeService::process();
+        SomeService::$value;
+        AnotherService::$count;
+        AnotherService::$configValue;
+        AnotherService::$defaultTimeout;
+    }
+}

--- a/tests/Rules/StaticAccess/Fixture/SomeService.php
+++ b/tests/Rules/StaticAccess/Fixture/SomeService.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture;
+
+class SomeService
+{
+    public static string $value = 'test';
+
+    public static function process(): void {}
+}

--- a/tests/Rules/StaticAccess/Fixture/StaticPropertyAccessExample.php
+++ b/tests/Rules/StaticAccess/Fixture/StaticPropertyAccessExample.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture;
+
+class StaticPropertyAccessExample
+{
+    protected static string $ownProperty = 'test';
+
+    public function test(): void
+    {
+        SomeService::process();
+        SomeService::$value;
+        AnotherService::$count;
+        self::$ownProperty;
+        static::$ownProperty;
+    }
+}

--- a/tests/Rules/StaticAccess/IgnorePatternTest.php
+++ b/tests/Rules/StaticAccess/IgnorePatternTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess;
+
+use Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<StaticAccessRule>
+ */
+class IgnorePatternTest extends RuleTestCase
+{
+    public function testIgnorePatternExample(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/IgnorePatternExample.php',
+            __DIR__ . '/Fixture/SomeService.php',
+            __DIR__ . '/Fixture/AnotherService.php',
+        ], [
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\SomeService', 'process'), 12],
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\AnotherService', 'handle'), 13],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignore-pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(StaticAccessRule::class);
+    }
+}

--- a/tests/Rules/StaticAccess/InvalidPatternTest.php
+++ b/tests/Rules/StaticAccess/InvalidPatternTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess;
+
+use InvalidArgumentException;
+use Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<StaticAccessRule>
+ */
+class InvalidPatternTest extends RuleTestCase
+{
+    public function testInvalidMethodPattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid regex pattern in method_ignore_pattern configuration');
+
+        $this->analyse([
+            __DIR__ . '/Fixture/IgnorePatternExample.php',
+            __DIR__ . '/Fixture/SomeService.php',
+            __DIR__ . '/Fixture/AnotherService.php',
+        ], []);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/invalid-method-pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(StaticAccessRule::class);
+    }
+}

--- a/tests/Rules/StaticAccess/InvalidPropertyPatternTest.php
+++ b/tests/Rules/StaticAccess/InvalidPropertyPatternTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess;
+
+use InvalidArgumentException;
+use Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<StaticAccessRule>
+ */
+class InvalidPropertyPatternTest extends RuleTestCase
+{
+    public function testInvalidPropertyPattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid regex pattern in property_ignore_pattern configuration');
+
+        $this->analyse([
+            __DIR__ . '/Fixture/StaticPropertyAccessExample.php',
+            __DIR__ . '/Fixture/SomeService.php',
+            __DIR__ . '/Fixture/AnotherService.php',
+        ], []);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/invalid-property-pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(StaticAccessRule::class);
+    }
+}

--- a/tests/Rules/StaticAccess/PropertyIgnorePatternTest.php
+++ b/tests/Rules/StaticAccess/PropertyIgnorePatternTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\StaticAccess;
+
+use Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<StaticAccessRule>
+ */
+class PropertyIgnorePatternTest extends RuleTestCase
+{
+    public function testPropertyIgnorePatternExample(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixture/PropertyIgnorePatternExample.php',
+            __DIR__ . '/Fixture/SomeService.php',
+            __DIR__ . '/Fixture/AnotherService.php',
+        ], [
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\SomeService', 'process'), 9],
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE_PROPERTY, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\SomeService', 'value'), 10],
+            [sprintf(StaticAccessRule::ERROR_MESSAGE_TEMPLATE_PROPERTY, 'Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\AnotherService', 'count'), 11],
+        ]);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/property-ignore-pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(StaticAccessRule::class);
+    }
+}

--- a/tests/Rules/StaticAccess/config/check-static-property-access.neon
+++ b/tests/Rules/StaticAccess/config/check-static-property-access.neon
@@ -1,0 +1,13 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule
+
+parameters:
+    meliorstan:
+        static_access:
+            exceptions: []
+            method_ignore_pattern: ''
+            property_ignore_pattern: ''
+            check_static_property_access: true

--- a/tests/Rules/StaticAccess/config/default.neon
+++ b/tests/Rules/StaticAccess/config/default.neon
@@ -1,0 +1,13 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule
+
+parameters:
+    meliorstan:
+        static_access:
+            exceptions: []
+            method_ignore_pattern: ''
+            property_ignore_pattern: ''
+            check_static_property_access: false

--- a/tests/Rules/StaticAccess/config/exceptions-wildcard.neon
+++ b/tests/Rules/StaticAccess/config/exceptions-wildcard.neon
@@ -1,0 +1,14 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule
+
+parameters:
+    meliorstan:
+        static_access:
+            exceptions:
+                - Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\Helpers\*
+            method_ignore_pattern: ''
+            property_ignore_pattern: ''
+            check_static_property_access: false

--- a/tests/Rules/StaticAccess/config/exceptions.neon
+++ b/tests/Rules/StaticAccess/config/exceptions.neon
@@ -1,0 +1,14 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule
+
+parameters:
+    meliorstan:
+        static_access:
+            exceptions:
+                - Orrison\MeliorStan\Tests\Rules\StaticAccess\Fixture\AllowedService
+            method_ignore_pattern: ''
+            property_ignore_pattern: ''
+            check_static_property_access: false

--- a/tests/Rules/StaticAccess/config/ignore-pattern.neon
+++ b/tests/Rules/StaticAccess/config/ignore-pattern.neon
@@ -1,0 +1,13 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule
+
+parameters:
+    meliorstan:
+        static_access:
+            exceptions: []
+            method_ignore_pattern: '/^(create|make|from)/'
+            property_ignore_pattern: ''
+            check_static_property_access: false

--- a/tests/Rules/StaticAccess/config/invalid-method-pattern.neon
+++ b/tests/Rules/StaticAccess/config/invalid-method-pattern.neon
@@ -1,0 +1,13 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule
+
+parameters:
+    meliorstan:
+        static_access:
+            exceptions: []
+            method_ignore_pattern: '/invalid[regex'  # Invalid regex - missing closing bracket
+            property_ignore_pattern: ''
+            check_static_property_access: false

--- a/tests/Rules/StaticAccess/config/invalid-property-pattern.neon
+++ b/tests/Rules/StaticAccess/config/invalid-property-pattern.neon
@@ -1,0 +1,13 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule
+
+parameters:
+    meliorstan:
+        static_access:
+            exceptions: []
+            method_ignore_pattern: ''
+            property_ignore_pattern: '/invalid[regex'  # Invalid regex - missing closing bracket
+            check_static_property_access: true

--- a/tests/Rules/StaticAccess/config/property-ignore-pattern.neon
+++ b/tests/Rules/StaticAccess/config/property-ignore-pattern.neon
@@ -1,0 +1,13 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\StaticAccess\StaticAccessRule
+
+parameters:
+    meliorstan:
+        static_access:
+            exceptions: []
+            method_ignore_pattern: ''
+            property_ignore_pattern: '/^(config|default)/'
+            check_static_property_access: true


### PR DESCRIPTION
This pull request introduces a new static access detection rule to the codebase, aimed at identifying and discouraging the use of static method calls and (optionally) static property access, which can lead to tightly coupled and hard-to-test code. The rule is highly configurable, supports exceptions and ignore patterns, and is fully documented and tested.

**Static Access Rule Implementation and Integration**

* Added a new rule, `StaticAccessRule`, which detects static method calls and, optionally, static property access, with configuration for exceptions and ignore patterns. (`src/Rules/StaticAccess/StaticAccessRule.php` [[1]](diffhunk://#diff-b0ab839c6fb5368e1aba0ab6b9e5b2e5321ac631a2da86d5de9ead3a3b458b6aR1-R156) `src/Rules/StaticAccess/Config.php` [[2]](diffhunk://#diff-8ea0eb452e1e9365726f335ce1809c8f3edadd4ea941806d7f283a0882480b8cR1-R53)
* Integrated the new rule into the configuration schema and default parameters, allowing users to enable and configure it in `extension.neon`. (`config/extension.neon` [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R103-R108) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R192-R196) [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R325-R331)
* Updated the `README.md` to document the new rule and its configuration options. (`README.md` [README.mdR126](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126))
* Added comprehensive documentation for the new rule, including usage, configuration, and examples. (`docs/StaticAccess.md` [docs/StaticAccess.mdR1-R169](diffhunk://#diff-9acb20b6c8b5474c9f937647db2edd040271e91abbc4e7a2df301d0043b8c1ebR1-R169))

**Testing for Static Access Rule**

* Introduced a suite of tests covering default behavior, exceptions (including wildcard exceptions), and static property access scenarios. (`tests/Rules/StaticAccess/DefaultTest.php` [[1]](diffhunk://#diff-2179c84f14c30f91e5f2eeee56562bbf29b9735092d855bad625b32fe917206cR1-R36) `tests/Rules/StaticAccess/ExceptionsTest.php` [[2]](diffhunk://#diff-373f42fb4c456a7d0e4cd078cb996fef0c047aeab95f3463eba8e1578fe5db1eR1-R36) `tests/Rules/StaticAccess/ExceptionsWildcardTest.php` [[3]](diffhunk://#diff-f2bef98c696403d90385b7e173e2c4f7b2c4e8659ee11b9831f3b5603f3935ceR1-R35) `tests/Rules/StaticAccess/CheckStaticPropertyAccessTest.php` [[4]](diffhunk://#diff-3230f1977b377d421d3ab04bc64eac04b6cbca30255289de739185da8c6b88e7R1-R36)
* Added test fixtures for various static access scenarios, including allowed and disallowed cases. (`tests/Rules/StaticAccess/Fixture/AllowedService.php` [[1]](diffhunk://#diff-23e1ce396f516dd2c2bee5667daa1059e1736fbf814670b410660ebae8c7db75R1-R8) `tests/Rules/StaticAccess/Fixture/AnotherService.php` [[2]](diffhunk://#diff-c2ef462fc1b79db6b0f5f5d5ab4c19d67b90b789f57332adfb66de5f954927faR1-R14) `tests/Rules/StaticAccess/Fixture/BaseExample.php` [[3]](diffhunk://#diff-ba0d224268a5104bf588c64e2e2eea50d16e36ff4e038bee026ad27df4021a61R1-R8) `tests/Rules/StaticAccess/Fixture/DefaultExample.php` [[4]](diffhunk://#diff-3578de6525ec240eccd7466998cb24f55cca5686c09af64d948047f4e2061737R1-R17) `tests/Rules/StaticAccess/Fixture/ExceptionsExample.php` [[5]](diffhunk://#diff-9f8e36019eca1e2157e715c8d4375e76af73db4822bbc2090e705ca169bb4ba8R1-R13) `tests/Rules/StaticAccess/Fixture/ExceptionsWildcardExample.php` [[6]](diffhunk://#diff-9354894e2f6f7c94a110467e1cbd807b45132f9f2d3133784eaa1bda85eeb0f6R1-R16) `tests/Rules/StaticAccess/Fixture/Helpers/ArrayHelper.php` [[7]](diffhunk://#diff-7d4bae9c52066b84d83d982dcd8940f0cf0f85a8304478f42a95c56b885262d4R1-R11)

This addition makes it easier to enforce best practices regarding dependency injection and reduces the risk of untestable, tightly coupled code.

Closes https://github.com/Orrison/MeliorStan/issues/30