### PR TITLE
Add IfStatementAssignment rule and documentation

### DIFF
--- a/.claude/skills/review-pr-comments/SKILL.md
+++ b/.claude/skills/review-pr-comments/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: review-pr-comments
+description: Review PR review comments and inline feedback, evaluate whether each is worth addressing, and recommend how to resolve valid ones. Re-runnable to catch new comments after previous ones are resolved.
+allowed-tools: Bash(gh *) Read Grep Glob
+---
+
+Review all open PR comments on the current branch's pull request. For each comment, evaluate its merit and provide a clear recommendation.
+
+## Steps
+
+1. **Find the PR** for the current branch:
+   ```
+   gh pr list --head $(git branch --show-current)
+   ```
+   If no PR exists, stop and tell the user.
+
+2. **Fetch all review comments** (inline code comments):
+   ```
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/comments
+   ```
+   Extract the PR number from step 1. Determine `{owner}/{repo}` from:
+   ```
+   gh repo view --json nameWithOwner -q .nameWithOwner
+   ```
+
+3. **For each comment**, read the file at the referenced path to get full context around the commented line. Use the `Read` tool with an offset around `line` to see surrounding code.
+
+4. **Evaluate each comment** and present your findings in this format:
+
+---
+
+### Comment on `{path}` line {line} — by {user}
+
+> {comment body quoted verbatim}
+
+**Verdict:** ✅ Worth addressing / ❌ Not worth addressing / ⚠️ Minor / already resolved
+
+**Reasoning:** {1–3 sentences explaining why the feedback is or isn't valid, referencing the actual code}
+
+**Recommendation:** {Specific, actionable description of the change to make — or why no change is needed. If already resolved, note that explicitly.}
+
+---
+
+5. **After all comments are reviewed**, provide a short summary:
+   - Total comments reviewed
+   - How many are worth addressing
+   - Any patterns or themes across the feedback
+
+## Important notes
+
+- Read the actual code at the referenced file/line before evaluating — do not rely solely on the comment description
+- If a comment references something that has already been fixed in the current working tree, mark it as **already resolved** and explain what the fix was
+- This command is designed to be re-run after resolving some comments — always fetch fresh data from the GitHub API, never rely on prior conversation context
+- Evaluate comments critically: not all automated or reviewer feedback is correct or appropriate for this project. Consider the project's CLAUDE.md conventions when judging validity
+- If `$ARGUMENTS` is provided, treat it as a PR number to review instead of auto-detecting from the current branch

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ parameters:
 | Rule | Description | Target |
 |------|-------------|---------|
 | **[ElseExpression](docs/ElseExpression.md)** | Discourages `else` expressions | Control Flow |
+| **[IfStatementAssignment](docs/IfStatementAssignment.md)** | Detects assignments inside `if` and `elseif` conditions | Control Flow |
 
 ### Design
 

--- a/docs/IfStatementAssignment.md
+++ b/docs/IfStatementAssignment.md
@@ -1,0 +1,74 @@
+# IfStatementAssignment
+
+Detects assignments inside `if` and `elseif` conditions.
+
+Assignments in if conditions are a code smell. They can easily mask logic errors — particularly typos where `=` was written instead of `==` or `===`. Additionally, when the assigned value is falsy (e.g., `0`, `null`, `false`, or an empty string), the condition will silently always evaluate to false, leading to bugs that can be difficult to spot.
+
+## Configuration
+
+This rule has no configuration options.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\IfStatementAssignment\IfStatementAssignmentRule
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+// ✗ Error: Avoid assignments inside if and elseif conditions.
+if ($foo = someFunction()) {
+    // ...
+}
+
+// ✗ Error: Avoid assignments inside if and elseif conditions.
+if ($bar = 0) {
+    // ...
+}
+
+// ✗ Error: Detect assignments nested in compound conditions
+if (($baz = someFunction()) && $other) {
+    // ...
+}
+
+// ✗ Error: Also flags assignments in elseif conditions
+if ($x > 1) {
+    // ...
+} elseif ($result = otherFunction()) {
+    // ...
+}
+
+// ✓ Valid: assign before the condition
+$foo = someFunction();
+if ($foo) {
+    // ...
+}
+
+// ✓ Valid: comparisons are allowed
+if ($value === null) {
+    // ...
+}
+
+// ✓ Valid: compound conditions without assignments
+if ($a && $b) {
+    // ...
+}
+```
+
+## Important Notes
+
+- Assignments are detected **recursively** throughout the condition expression, including those nested inside compound conditions with `&&`, `||`, and parentheses.
+- Both `if` and `elseif` conditions are checked.
+- `while` loop conditions are not checked by this rule.
+- To use the result of a function call as both an assigned value and a condition, assign it on a separate line before the `if` statement.

--- a/docs/IfStatementAssignment.md
+++ b/docs/IfStatementAssignment.md
@@ -47,12 +47,12 @@ if ($count += 1) {
     // ...
 }
 
-// ✗ Error: Detect assignments nested in compound conditions
+// ✗ Error: Avoid assignments inside if and elseif conditions.
 if (($baz = someFunction()) && $other) {
     // ...
 }
 
-// ✗ Error: Also flags assignments in elseif conditions
+// ✗ Error: Avoid assignments inside if and elseif conditions.
 if ($x > 1) {
     // ...
 } elseif ($result = otherFunction()) {

--- a/docs/IfStatementAssignment.md
+++ b/docs/IfStatementAssignment.md
@@ -2,7 +2,7 @@
 
 Detects assignments inside `if` and `elseif` conditions.
 
-Assignments in if conditions are a code smell. They can easily mask logic errors — particularly typos where `=` was written instead of `==` or `===`. Additionally, when the assigned value is falsy (e.g., `0`, `null`, `false`, or an empty string), the condition will silently always evaluate to false, leading to bugs that can be difficult to spot.
+Assignments in if conditions are a code smell. They can easily mask logic errors — particularly typos where `=` was written instead of `==` or `===`. Additionally, when the assigned value is falsy (e.g., `0`, `null`, `false`, or an empty string), the condition will silently always evaluate to false, leading to bugs that can be difficult to spot. All assignment forms are flagged: plain assignment (`=`), reference assignment (`=&`), and compound assignments (`+=`, `??=`, `.=`, etc.).
 
 ## Configuration
 
@@ -37,6 +37,16 @@ if ($bar = 0) {
     // ...
 }
 
+// ✗ Error: Avoid assignments inside if and elseif conditions.
+if ($ref = &$source) {
+    // ...
+}
+
+// ✗ Error: Avoid assignments inside if and elseif conditions.
+if ($count += 1) {
+    // ...
+}
+
 // ✗ Error: Detect assignments nested in compound conditions
 if (($baz = someFunction()) && $other) {
     // ...
@@ -68,6 +78,7 @@ if ($a && $b) {
 
 ## Important Notes
 
+- All assignment forms are detected: plain `=`, reference `=&`, and compound operators (`+=`, `??=`, `.=`, etc.).
 - Assignments are detected **recursively** throughout the condition expression, including those nested inside compound conditions with `&&`, `||`, and parentheses.
 - Both `if` and `elseif` conditions are checked.
 - `while` loop conditions are not checked by this rule.

--- a/src/Rules/IfStatementAssignment/IfStatementAssignmentRule.php
+++ b/src/Rules/IfStatementAssignment/IfStatementAssignmentRule.php
@@ -4,6 +4,8 @@ namespace Orrison\MeliorStan\Rules\IfStatementAssignment;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp;
+use PhpParser\Node\Expr\AssignRef;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
@@ -52,10 +54,17 @@ class IfStatementAssignmentRule implements Rule
     }
 
     /**
-     * @return Assign[]
+     * @return array<Assign|AssignRef|AssignOp>
      */
     protected function findAssignments(Node $expr): array
     {
-        return (new NodeFinder())->findInstanceOf($expr, Assign::class);
+        /** @var array<Assign|AssignRef|AssignOp> $assignments */
+        $assignments = (new NodeFinder())->find($expr, function (Node $node): bool {
+            return $node instanceof Assign
+                || $node instanceof AssignRef
+                || $node instanceof AssignOp;
+        });
+
+        return $assignments;
     }
 }

--- a/src/Rules/IfStatementAssignment/IfStatementAssignmentRule.php
+++ b/src/Rules/IfStatementAssignment/IfStatementAssignmentRule.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\IfStatementAssignment;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<If_>
+ */
+class IfStatementAssignmentRule implements Rule
+{
+    public const string ERROR_MESSAGE = 'Avoid assignments inside if and elseif conditions.';
+
+    public function getNodeType(): string
+    {
+        return If_::class;
+    }
+
+    /**
+     * @param If_ $node
+     *
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $errors = [];
+
+        foreach ($this->findAssignments($node->cond) as $assign) {
+            $errors[] = RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                ->identifier('MeliorStan.ifStatementAssignment')
+                ->line($assign->getStartLine())
+                ->build();
+        }
+
+        foreach ($node->elseifs as $elseif) {
+            foreach ($this->findAssignments($elseif->cond) as $assign) {
+                $errors[] = RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                    ->identifier('MeliorStan.ifStatementAssignment')
+                    ->line($assign->getStartLine())
+                    ->build();
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return Assign[]
+     */
+    protected function findAssignments(Node $expr): array
+    {
+        return (new NodeFinder())->findInstanceOf($expr, Assign::class);
+    }
+}

--- a/tests/Rules/IfStatementAssignment/Fixture/AssignOpInIfCondition.php
+++ b/tests/Rules/IfStatementAssignment/Fixture/AssignOpInIfCondition.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\IfStatementAssignment\Fixture;
+
+class AssignOpInIfCondition
+{
+    public function withCoalesceAssignment(): void
+    {
+        $foo = null;
+
+        if ($foo ??= someFunction()) {
+        }
+    }
+
+    public function withPlusAssignment(): void
+    {
+        $count = 0;
+
+        if ($count += 1) {
+        }
+    }
+}

--- a/tests/Rules/IfStatementAssignment/Fixture/AssignRefInIfCondition.php
+++ b/tests/Rules/IfStatementAssignment/Fixture/AssignRefInIfCondition.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\IfStatementAssignment\Fixture;
+
+class AssignRefInIfCondition
+{
+    public function withReferenceAssignment(): void
+    {
+        $source = someFunction();
+
+        if ($ref = &$source) {
+        }
+    }
+}

--- a/tests/Rules/IfStatementAssignment/Fixture/AssignmentInElseIfCondition.php
+++ b/tests/Rules/IfStatementAssignment/Fixture/AssignmentInElseIfCondition.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\IfStatementAssignment\Fixture;
+
+class AssignmentInElseIfCondition
+{
+    public function withElseIfAssignment(): void
+    {
+        if (true) {
+        } elseif ($foo = someFunction()) {
+        }
+    }
+
+    public function withMultipleElseIfAssignments(): void
+    {
+        if (true) {
+        } elseif ($foo = someFunction()) {
+        } elseif ($bar = otherFunction()) {
+        }
+    }
+}

--- a/tests/Rules/IfStatementAssignment/Fixture/AssignmentInIfCondition.php
+++ b/tests/Rules/IfStatementAssignment/Fixture/AssignmentInIfCondition.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\IfStatementAssignment\Fixture;
+
+class AssignmentInIfCondition
+{
+    public function withFunctionCallAssignment(): void
+    {
+        if ($foo = someFunction()) {
+        }
+    }
+
+    public function withLiteralAssignment(): void
+    {
+        if ($bar = 0) {
+        }
+    }
+
+    public function withMethodCallAssignment(): void
+    {
+        if ($baz = $this->getResult()) {
+        }
+    }
+
+    protected function getResult(): mixed
+    {
+        return null;
+    }
+}

--- a/tests/Rules/IfStatementAssignment/Fixture/NestedAssignmentInCondition.php
+++ b/tests/Rules/IfStatementAssignment/Fixture/NestedAssignmentInCondition.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\IfStatementAssignment\Fixture;
+
+class NestedAssignmentInCondition
+{
+    public function withAndCondition(): void
+    {
+        if (($foo = someFunction()) && true) {
+        }
+    }
+
+    public function withOrCondition(): void
+    {
+        if (true || ($bar = someFunction())) {
+        }
+    }
+}

--- a/tests/Rules/IfStatementAssignment/Fixture/ValidIfConditions.php
+++ b/tests/Rules/IfStatementAssignment/Fixture/ValidIfConditions.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\IfStatementAssignment\Fixture;
+
+class ValidIfConditions
+{
+    public function withPreAssignment(): void
+    {
+        $foo = someFunction();
+
+        if ($foo) {
+        }
+    }
+
+    public function withStrictComparison(): void
+    {
+        $value = someFunction();
+
+        if ($value === null) {
+        }
+    }
+
+    public function withLooseComparison(): void
+    {
+        $value = someFunction();
+
+        if ($value == false) {
+        }
+    }
+
+    public function withValidElseIf(): void
+    {
+        if (true) {
+        } elseif (false) {
+        }
+    }
+}

--- a/tests/Rules/IfStatementAssignment/IfStatementAssignmentTest.php
+++ b/tests/Rules/IfStatementAssignment/IfStatementAssignmentTest.php
@@ -26,6 +26,8 @@ class IfStatementAssignmentTest extends RuleTestCase
                 __DIR__ . '/Fixture/AssignmentInElseIfCondition.php',
                 __DIR__ . '/Fixture/NestedAssignmentInCondition.php',
                 __DIR__ . '/Fixture/ValidIfConditions.php',
+                __DIR__ . '/Fixture/AssignOpInIfCondition.php',
+                __DIR__ . '/Fixture/AssignRefInIfCondition.php',
             ],
             [
                 [IfStatementAssignmentRule::ERROR_MESSAGE, 9],
@@ -36,6 +38,9 @@ class IfStatementAssignmentTest extends RuleTestCase
                 [IfStatementAssignmentRule::ERROR_MESSAGE, 18],
                 [IfStatementAssignmentRule::ERROR_MESSAGE, 9],
                 [IfStatementAssignmentRule::ERROR_MESSAGE, 15],
+                [IfStatementAssignmentRule::ERROR_MESSAGE, 11],
+                [IfStatementAssignmentRule::ERROR_MESSAGE, 19],
+                [IfStatementAssignmentRule::ERROR_MESSAGE, 11],
             ]
         );
     }

--- a/tests/Rules/IfStatementAssignment/IfStatementAssignmentTest.php
+++ b/tests/Rules/IfStatementAssignment/IfStatementAssignmentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\IfStatementAssignment;
+
+use Orrison\MeliorStan\Rules\IfStatementAssignment\IfStatementAssignmentRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<IfStatementAssignmentRule>
+ */
+class IfStatementAssignmentTest extends RuleTestCase
+{
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/config/default.neon',
+        ];
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/AssignmentInIfCondition.php',
+                __DIR__ . '/Fixture/AssignmentInElseIfCondition.php',
+                __DIR__ . '/Fixture/NestedAssignmentInCondition.php',
+                __DIR__ . '/Fixture/ValidIfConditions.php',
+            ],
+            [
+                [IfStatementAssignmentRule::ERROR_MESSAGE, 9],
+                [IfStatementAssignmentRule::ERROR_MESSAGE, 15],
+                [IfStatementAssignmentRule::ERROR_MESSAGE, 21],
+                [IfStatementAssignmentRule::ERROR_MESSAGE, 10],
+                [IfStatementAssignmentRule::ERROR_MESSAGE, 17],
+                [IfStatementAssignmentRule::ERROR_MESSAGE, 18],
+                [IfStatementAssignmentRule::ERROR_MESSAGE, 9],
+                [IfStatementAssignmentRule::ERROR_MESSAGE, 15],
+            ]
+        );
+    }
+
+    protected function getRule(): Rule
+    {
+        return new IfStatementAssignmentRule();
+    }
+}

--- a/tests/Rules/IfStatementAssignment/config/default.neon
+++ b/tests/Rules/IfStatementAssignment/config/default.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\IfStatementAssignment\IfStatementAssignmentRule


### PR DESCRIPTION
This pull request introduces a new rule, `IfStatementAssignment`, which detects and discourages assignments inside `if` and `elseif` conditions to prevent common logic errors. The implementation includes the rule logic, documentation, and a comprehensive test suite with various fixture cases.

**New Rule: Assignment in If/Elseif Conditions**

- Added the `IfStatementAssignmentRule` to flag assignments inside `if` and `elseif` conditions, including nested assignments within compound conditions. This helps prevent accidental assignment (`=`) instead of comparison (`==`, `===`) and other subtle bugs.

**Documentation**

- Created `docs/IfStatementAssignment.md` to explain the rule, its motivation, configuration, usage, and code examples of both violations and valid patterns.
- Updated `README.md` to include the new rule in the parameters table.

**Testing**

- Added a dedicated test case, `IfStatementAssignmentTest`, covering various scenarios including assignments in `if`, `elseif`, and nested conditions, as well as valid cases.
- Provided fixture files for assignment in `if`, `elseif`, and nested conditions, as well as valid patterns that should not be flagged. [[1]](diffhunk://#diff-e183559d9bcaf76c119f3c0022e6babb42c6d9c5329c2f1c2c8a337979d766b9R1-R29) [[2]](diffhunk://#diff-520719368716ec5dc5fe5fc1ff6339cb9ac173882e376069e100dc00c9ce03a2R1-R21) [[3]](diffhunk://#diff-04e5e99e673a5acff507ef9f752c4501c87953af0b2a4939470ea72f0432ca52R1-R37)
- Included a test configuration file to enable the rule for testing.

Closes https://github.com/Orrison/MeliorStan/issues/31