### PR TITLE
Implement MissingImport rule with configuration and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ parameters:
 | **[BooleanArgumentFlag](docs/BooleanArgumentFlag.md)** | Detects boolean parameters in functions and methods that may indicate multiple responsibilities | Methods, Functions, Closures |
 | **[LongVariable](docs/LongVariable.md)** | Limits variable name length | Variables |
 | **[MissingClosureParameterTypehint](docs/MissingClosureParameterTypehint.md)** | Requires type hints on closure parameters | Closures |
-| **[MissingImport](docs/MissingImport.md)** | Detects classes referenced by fully qualified name instead of being imported with a `use` statement | All code contexts |
+| **[MissingImport](docs/MissingImport.md)** | Detects types referenced by fully qualified name instead of being imported with a `use` statement | Type-reference positions |
 | **[ShortMethodName](docs/ShortMethodName.md)** | Enforces minimum method name length | Methods |
 | **[ShortVariable](docs/ShortVariable.md)** | Enforces minimum variable name length | Variables |
 | **[ForbidPestPhpOnly](docs/ForbidPestPhpOnly.md)** | Prevents committed Pest tests from using the `only()` filter | Tests |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ parameters:
 | **[BooleanArgumentFlag](docs/BooleanArgumentFlag.md)** | Detects boolean parameters in functions and methods that may indicate multiple responsibilities | Methods, Functions, Closures |
 | **[LongVariable](docs/LongVariable.md)** | Limits variable name length | Variables |
 | **[MissingClosureParameterTypehint](docs/MissingClosureParameterTypehint.md)** | Requires type hints on closure parameters | Closures |
+| **[MissingImport](docs/MissingImport.md)** | Detects classes referenced by fully qualified name instead of being imported with a `use` statement | All code contexts |
 | **[ShortMethodName](docs/ShortMethodName.md)** | Enforces minimum method name length | Methods |
 | **[ShortVariable](docs/ShortVariable.md)** | Enforces minimum variable name length | Variables |
 | **[ForbidPestPhpOnly](docs/ForbidPestPhpOnly.md)** | Prevents committed Pest tests from using the `only()` filter | Tests |

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -106,6 +106,10 @@ parametersSchema:
             property_ignore_pattern: string(),
             check_static_property_access: bool(),
         ]),
+        missing_import: structure([
+            ignore_global: bool(),
+            exceptions: arrayOf(string()),
+        ]),
     ])
 
 # default parameters
@@ -194,6 +198,9 @@ parameters:
             method_ignore_pattern: ''
             property_ignore_pattern: ''
             check_static_property_access: false
+        missing_import:
+            ignore_global: false
+            exceptions: []
 
 services:
     -
@@ -329,3 +336,8 @@ services:
             - %meliorstan.static_access.method_ignore_pattern%
             - %meliorstan.static_access.property_ignore_pattern%
             - %meliorstan.static_access.check_static_property_access%
+    -
+        factory: Orrison\MeliorStan\Rules\MissingImport\Config
+        arguments:
+            - %meliorstan.missing_import.ignore_global%
+            - %meliorstan.missing_import.exceptions%

--- a/docs/MissingImport.md
+++ b/docs/MissingImport.md
@@ -1,6 +1,6 @@
 # MissingImport
 
-Detects classes, interfaces, enums, and traits referenced by their fully qualified name (with a leading backslash) instead of being imported with a `use` statement at the top of the file.
+Detects classes, interfaces, enums, and traits referenced by their fully qualified name (with a leading backslash) instead of being imported with a `use` statement.
 
 Referencing types by their fully qualified name obscures a file's dependencies. Using `use` statements makes every dependency immediately visible at a glance and keeps call-site code shorter and more readable.
 
@@ -60,24 +60,30 @@ class UserController
         return new User();
     }
 
-    // ✗ Error: Class "\App\Services\UserService" should not be referenced by its fully qualified name.
+    // ✗ Error: Type "\App\Traits\Auditable" should not be referenced by its fully qualified name.
+    use \App\Traits\Auditable;
+
+    // ✗ Error: Type "\App\Models\UserStatus" should not be referenced by its fully qualified name.
+    public const \App\Models\UserStatus DEFAULT_STATUS = \App\Models\UserStatus::Active;
+
+    // ✗ Error: Type "\App\Services\UserService" should not be referenced by its fully qualified name.
     public function store(\App\Services\UserService $service): void {}
 
-    // ✗ Error: Class "\App\Services\UserService" should not be referenced by its fully qualified name.
+    // ✗ Error: Type "\App\Services\UserService" should not be referenced by its fully qualified name.
     public function index(): void
     {
         $service = new \App\Services\UserService();
         \App\Services\UserService::boot();
     }
 
-    // ✗ Error: Class "\stdClass" should not be referenced by its fully qualified name.
+    // ✗ Error: Type "\stdClass" should not be referenced by its fully qualified name.
     public function raw(): void
     {
         $obj = new \stdClass();
     }
 }
 
-// ✗ Error: Class "\App\Contracts\HasLabel" should not be referenced by its fully qualified name.
+// ✗ Error: Type "\App\Contracts\HasLabel" should not be referenced by its fully qualified name.
 enum Status: string implements \App\Contracts\HasLabel
 {
     case Active = 'active';
@@ -143,9 +149,10 @@ class UserController
 
 ## Important Notes
 
-The rule inspects fully qualified names in all code contexts, including:
+The rule inspects fully qualified names in all common type-reference positions, including:
 
 - Property type declarations (`private \Foo\Bar $prop`)
+- Typed class constants — PHP 8.3+ (`public const \Foo\Bar NAME = ...`)
 - Parameter type declarations (`function foo(\Foo\Bar $x)`)
 - Return type declarations (`function foo(): \Foo\Bar`)
 - Union, intersection, and nullable types (`\Foo\Bar|\Baz\Qux`, `?\Foo\Bar`)
@@ -153,6 +160,7 @@ The rule inspects fully qualified names in all code contexts, including:
 - Static calls and property access (`\Foo\Bar::method()`, `\Foo\Bar::$prop`, `\Foo\Bar::CONST`)
 - `instanceof` checks (`$x instanceof \Foo\Bar`)
 - `catch` blocks (`catch (\Foo\Bar $e)`)
+- Trait use inside a class or trait body (`use \Foo\Bar`)
 - Class `extends` and `implements` (`class Foo extends \Bar implements \Baz`)
 - Interface `extends` (`interface Foo extends \Bar`)
 - Enum `implements` (`enum Foo implements \Bar`)

--- a/docs/MissingImport.md
+++ b/docs/MissingImport.md
@@ -1,0 +1,160 @@
+# MissingImport
+
+Detects classes, interfaces, enums, and traits referenced by their fully qualified name (with a leading backslash) instead of being imported with a `use` statement at the top of the file.
+
+Referencing types by their fully qualified name obscures a file's dependencies. Using `use` statements makes every dependency immediately visible at a glance and keeps call-site code shorter and more readable.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `ignore_global`
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Description**: When `true`, classes that live in PHP's global namespace (e.g. `\stdClass`, `\Exception`, `\DateTime`) are allowed to be referenced by their fully qualified name without a `use` statement. When `false` (default), global-namespace classes are treated the same as namespaced ones.
+
+### `exceptions`
+
+- **Type**: `string[]`
+- **Default**: `[]`
+- **Description**: A list of fully qualified class names (without the leading `\`) that are always allowed to be referenced as FQCNs, even when `ignore_global` is `false`. Useful for intentional or generated references that are exempt from this rule (e.g. `App\Providers\AppServiceProvider`).
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\MissingImport\MissingImportRule
+
+parameters:
+    meliorstan:
+        missing_import:
+            ignore_global: false
+            exceptions: []
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+
+class UserController
+{
+    // ✓ Valid — imported via use statement
+    private User $user;
+
+    // ✓ Valid — imported via use statement
+    public function show(User $user): User
+    {
+        return new User();
+    }
+
+    // ✗ Error: Class "\App\Services\UserService" should not be referenced by its fully qualified name.
+    public function store(\App\Services\UserService $service): void {}
+
+    // ✗ Error: Class "\App\Services\UserService" should not be referenced by its fully qualified name.
+    public function index(): void
+    {
+        $service = new \App\Services\UserService();
+        \App\Services\UserService::boot();
+    }
+
+    // ✗ Error: Class "\stdClass" should not be referenced by its fully qualified name.
+    public function raw(): void
+    {
+        $obj = new \stdClass();
+    }
+}
+
+// ✗ Error: Class "\App\Contracts\HasLabel" should not be referenced by its fully qualified name.
+enum Status: string implements \App\Contracts\HasLabel
+{
+    case Active = 'active';
+
+    // ✓ Valid — imported via use statement
+    public function label(User $user): string
+    {
+        return $this->value;
+    }
+}
+```
+
+### Configuration Examples
+
+#### `ignore_global`
+
+```neon
+parameters:
+    meliorstan:
+        missing_import:
+            ignore_global: true
+```
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+class UserController
+{
+    public function raw(): void
+    {
+        $obj = new \stdClass();   // ✓ Now valid
+        $dt  = new \DateTime();   // ✓ Now valid
+    }
+}
+```
+
+#### `exceptions`
+
+```neon
+parameters:
+    meliorstan:
+        missing_import:
+            exceptions:
+                - App\Services\UserService
+```
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+class UserController
+{
+    // ✓ Now valid — listed in exceptions
+    public function index(): void
+    {
+        $service = new \App\Services\UserService();
+    }
+}
+```
+
+## Important Notes
+
+The rule inspects fully qualified names in all code contexts, including:
+
+- Property type declarations (`private \Foo\Bar $prop`)
+- Parameter type declarations (`function foo(\Foo\Bar $x)`)
+- Return type declarations (`function foo(): \Foo\Bar`)
+- Union, intersection, and nullable types (`\Foo\Bar|\Baz\Qux`, `?\Foo\Bar`)
+- `new` expressions (`new \Foo\Bar()`)
+- Static calls and property access (`\Foo\Bar::method()`, `\Foo\Bar::$prop`, `\Foo\Bar::CONST`)
+- `instanceof` checks (`$x instanceof \Foo\Bar`)
+- `catch` blocks (`catch (\Foo\Bar $e)`)
+- Class `extends` and `implements` (`class Foo extends \Bar implements \Baz`)
+- Interface `extends` (`interface Foo extends \Bar`)
+- Enum `implements` (`enum Foo implements \Bar`)
+
+Names that were resolved from a `use` import (e.g. `SomeService` after `use App\Services\SomeService`) are never flagged, only names that were explicitly written with a leading backslash in the source code.

--- a/php-cs-fixer.php
+++ b/php-cs-fixer.php
@@ -137,6 +137,9 @@ $finder = Finder::create()
         [
             'vendor',
             'node_modules',
+            // MissingImport fixtures intentionally contain fully-qualified class names
+            // that should not be auto-imported by the fully_qualified_strict_types fixer.
+            'tests/Rules/MissingImport/Fixture',
         ]
     )
     ->name('*.php')

--- a/src/Rules/MissingImport/Config.php
+++ b/src/Rules/MissingImport/Config.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\MissingImport;
+
+class Config
+{
+    /**
+     * @param string[] $exceptions
+     */
+    public function __construct(
+        protected bool $ignoreGlobal,
+        protected array $exceptions,
+    ) {}
+
+    public function getIgnoreGlobal(): bool
+    {
+        return $this->ignoreGlobal;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+}

--- a/src/Rules/MissingImport/MissingImportRule.php
+++ b/src/Rules/MissingImport/MissingImportRule.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\MissingImport;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\UnionType;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Node>
+ */
+class MissingImportRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = 'Class "\\%s" should not be referenced by its fully qualified name. Import it with a "use" statement instead.';
+
+    public function __construct(
+        protected Config $config,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return Node::class;
+    }
+
+    /**
+     * @return list<RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // --- Type annotation positions ---
+
+        // Parameter types: function foo(\Foo\Bar $x)
+        if ($node instanceof Param) {
+            return $this->buildErrors($this->extractFqcnsFromType($node->type));
+        }
+
+        // Property types: private \Foo\Bar $prop;
+        if ($node instanceof Property) {
+            return $this->buildErrors($this->extractFqcnsFromType($node->type));
+        }
+
+        // Return types: function foo(): \Foo\Bar
+        if ($node instanceof ClassMethod
+            || $node instanceof Function_
+            || $node instanceof Closure
+            || $node instanceof ArrowFunction) {
+            return $this->buildErrors($this->extractFqcnsFromType($node->returnType));
+        }
+
+        // --- Expression positions ---
+
+        // new \Foo\Bar()  /  $x instanceof \Foo\Bar
+        if (($node instanceof New_ || $node instanceof Instanceof_)
+            && $node->class instanceof FullyQualified
+            && $this->isExplicitFqcn($node->class)) {
+            return $this->buildErrors([$node->class->toString()]);
+        }
+
+        // \Foo\Bar::method()  /  \Foo\Bar::$prop  /  \Foo\Bar::CONST
+        if (($node instanceof StaticCall
+            || $node instanceof StaticPropertyFetch
+            || $node instanceof ClassConstFetch)
+            && $node->class instanceof FullyQualified
+            && $this->isExplicitFqcn($node->class)) {
+            return $this->buildErrors([$node->class->toString()]);
+        }
+
+        // --- Class declaration positions ---
+
+        // class Foo extends \Bar implements \Baz
+        // interface Foo extends \Bar
+        // enum Foo implements \Bar
+        if ($node instanceof InClassNode) { // @phpstan-ignore phpstanApi.instanceofAssumption
+            $classLike = $node->getOriginalNode();
+            $fqcns = [];
+
+            if ($classLike instanceof Class_) {
+                if ($classLike->extends instanceof FullyQualified && $this->isExplicitFqcn($classLike->extends)) {
+                    $fqcns[] = $classLike->extends->toString();
+                }
+
+                foreach ($classLike->implements as $interface) {
+                    if ($interface instanceof FullyQualified && $this->isExplicitFqcn($interface)) {
+                        $fqcns[] = $interface->toString();
+                    }
+                }
+            } elseif ($classLike instanceof Interface_) {
+                foreach ($classLike->extends as $extend) {
+                    if ($extend instanceof FullyQualified && $this->isExplicitFqcn($extend)) {
+                        $fqcns[] = $extend->toString();
+                    }
+                }
+            } elseif ($classLike instanceof Enum_) {
+                foreach ($classLike->implements as $interface) {
+                    if ($interface instanceof FullyQualified && $this->isExplicitFqcn($interface)) {
+                        $fqcns[] = $interface->toString();
+                    }
+                }
+            }
+
+            return $this->buildErrors($fqcns);
+        }
+
+        // catch (\Foo\Bar $e) — types is a Name[]
+        if ($node instanceof Catch_) {
+            $fqcns = array_values(array_map(
+                fn (Name $type): string => $type->toString(),
+                array_filter(
+                    $node->types,
+                    fn (Name $type): bool => $type instanceof FullyQualified && $this->isExplicitFqcn($type)
+                )
+            ));
+
+            return $this->buildErrors($fqcns);
+        }
+
+        return [];
+    }
+
+    /**
+     * Extracts all explicitly-written FullyQualified names from a type node,
+     * recursively unwrapping union, intersection, and nullable types.
+     *
+     * @return string[]
+     */
+    protected function extractFqcnsFromType(Node|null $type): array
+    {
+        if ($type === null) {
+            return [];
+        }
+
+        if ($type instanceof FullyQualified && $this->isExplicitFqcn($type)) {
+            return [$type->toString()];
+        }
+
+        if ($type instanceof UnionType || $type instanceof IntersectionType) {
+            $fqcns = [];
+
+            foreach ($type->types as $part) {
+                $fqcns = array_merge($fqcns, $this->extractFqcnsFromType($part));
+            }
+
+            return $fqcns;
+        }
+
+        if ($type instanceof NullableType) {
+            return $this->extractFqcnsFromType($type->type);
+        }
+
+        return [];
+    }
+
+    /**
+     * Returns true when the FullyQualified name was explicitly written with a
+     * leading backslash in source code, rather than being resolved from an
+     * imported (shorter) name by PHPStan's NameResolver.
+     *
+     * When NameResolver resolves an unqualified name (e.g. `SomeService` after
+     * `use App\Services\SomeService`) it sets the `originalName` attribute on
+     * the resulting FullyQualified node to the original unqualified Name node.
+     * An already-FullyQualified name written in source has no `originalName`.
+     */
+    protected function isExplicitFqcn(FullyQualified $node): bool
+    {
+        $originalName = $node->getAttribute('originalName');
+
+        // If originalName is a plain Name (not itself FullyQualified), the
+        // reference was resolved from an import — not an explicit FQCN.
+        return ! ($originalName instanceof Name && ! $originalName instanceof FullyQualified);
+    }
+
+    /**
+     * @param string[] $classNames
+     *
+     * @return list<RuleError>
+     */
+    protected function buildErrors(array $classNames): array
+    {
+        $errors = [];
+
+        foreach ($classNames as $className) {
+            // Skip global-namespace classes (no backslash in the name)
+            if ($this->config->getIgnoreGlobal() && ! str_contains($className, '\\')) {
+                continue;
+            }
+
+            // Skip explicitly allowed classes
+            if (in_array($className, $this->config->getExceptions(), true)) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE_TEMPLATE, $className))
+                ->identifier('MeliorStan.missingImport')
+                ->build();
+        }
+
+        return $errors;
+    }
+}

--- a/src/Rules/MissingImport/MissingImportRule.php
+++ b/src/Rules/MissingImport/MissingImportRule.php
@@ -17,11 +17,13 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\TraitUse;
 use PhpParser\Node\UnionType;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassNode;
@@ -34,7 +36,7 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 class MissingImportRule implements Rule
 {
-    public const string ERROR_MESSAGE_TEMPLATE = 'Class "\\%s" should not be referenced by its fully qualified name. Import it with a "use" statement instead.';
+    public const string ERROR_MESSAGE_TEMPLATE = 'Type "\\%s" should not be referenced by its fully qualified name. Import it with a "use" statement instead.';
 
     public function __construct(
         protected Config $config,
@@ -59,6 +61,11 @@ class MissingImportRule implements Rule
 
         // Property types: private \Foo\Bar $prop;
         if ($node instanceof Property) {
+            return $this->buildErrors($this->extractFqcnsFromType($node->type));
+        }
+
+        // Typed class constants (PHP 8.3+): public const \Foo\Bar NAME = ...;
+        if ($node instanceof ClassConst) {
             return $this->buildErrors($this->extractFqcnsFromType($node->type));
         }
 
@@ -118,6 +125,19 @@ class MissingImportRule implements Rule
                     if ($interface instanceof FullyQualified && $this->isExplicitFqcn($interface)) {
                         $fqcns[] = $interface->toString();
                     }
+                }
+            }
+
+            return $this->buildErrors($fqcns);
+        }
+
+        // Trait use: use \Foo\Bar; (inside a class/trait body)
+        if ($node instanceof TraitUse) {
+            $fqcns = [];
+
+            foreach ($node->traits as $trait) {
+                if ($trait instanceof FullyQualified && $this->isExplicitFqcn($trait)) {
+                    $fqcns[] = $trait->toString();
                 }
             }
 

--- a/tests/Rules/MissingImport/DefaultTest.php
+++ b/tests/Rules/MissingImport/DefaultTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport;
+
+use Orrison\MeliorStan\Rules\MissingImport\MissingImportRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<MissingImportRule>
+ */
+class DefaultTest extends RuleTestCase
+{
+    public function testExplicitFqcnUsages(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ExplicitFqcnUsages.php'],
+            [
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 7],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Services\SomeService'), 11],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Services\SomeService'), 16],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 19],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 21],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 23],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 28],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Exceptions\CustomException'), 35],
+            ]
+        );
+    }
+
+    public function testGlobalNamespaceClassesAreAlsoFlagged(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/GlobalNamespaceUsages.php'],
+            [
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'stdClass'), 9],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'DateTime'), 10],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'Exception'), 11],
+            ]
+        );
+    }
+
+    public function testImportedUsagesHaveNoViolations(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ImportedUsages.php'],
+            []
+        );
+    }
+
+    public function testEnumFqcnUsages(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/EnumUsages.php'],
+            [
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Contracts\HasLabel'), 5],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 9],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Services\SomeService'), 9],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 11],
+            ]
+        );
+    }
+
+    public function testEnumImportedUsagesHaveNoViolations(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/EnumImportedUsages.php'],
+            []
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/default.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(MissingImportRule::class);
+    }
+}

--- a/tests/Rules/MissingImport/DefaultTest.php
+++ b/tests/Rules/MissingImport/DefaultTest.php
@@ -69,6 +69,42 @@ class DefaultTest extends RuleTestCase
         );
     }
 
+    public function testTypedClassConstFqcnUsages(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ClassConstFqcnUsages.php'],
+            [
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 7],
+            ]
+        );
+    }
+
+    public function testTypedClassConstImportedUsagesHaveNoViolations(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ClassConstImportedUsages.php'],
+            []
+        );
+    }
+
+    public function testTraitUseFqcnUsages(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/TraitUseFqcnUsages.php'],
+            [
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Traits\SomeTrait'), 7],
+            ]
+        );
+    }
+
+    public function testTraitUseImportedUsagesHaveNoViolations(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/TraitUseImportedUsages.php'],
+            []
+        );
+    }
+
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/config/default.neon'];

--- a/tests/Rules/MissingImport/ExceptionsTest.php
+++ b/tests/Rules/MissingImport/ExceptionsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport;
+
+use Orrison\MeliorStan\Rules\MissingImport\MissingImportRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<MissingImportRule>
+ */
+class ExceptionsTest extends RuleTestCase
+{
+    public function testExceptedClassIsAllowed(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ExceptionsFqcnUsages.php'],
+            [
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 14],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/exceptions.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(MissingImportRule::class);
+    }
+}

--- a/tests/Rules/MissingImport/Fixture/ClassConstFqcnUsages.php
+++ b/tests/Rules/MissingImport/Fixture/ClassConstFqcnUsages.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport\Fixture;
+
+class ClassConstFqcnUsages
+{
+    public const \App\Models\User|null THE_USER = null;
+}

--- a/tests/Rules/MissingImport/Fixture/ClassConstImportedUsages.php
+++ b/tests/Rules/MissingImport/Fixture/ClassConstImportedUsages.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport\Fixture;
+
+use App\Models\User;
+
+class ClassConstImportedUsages
+{
+    public const User|null THE_USER = null;
+}

--- a/tests/Rules/MissingImport/Fixture/EnumImportedUsages.php
+++ b/tests/Rules/MissingImport/Fixture/EnumImportedUsages.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport\Fixture;
+
+use App\Contracts\HasLabel;
+use App\Models\User;
+use App\Services\SomeService;
+
+enum EnumImportedUsages: string implements HasLabel
+{
+    case Active = 'active';
+
+    public function label(SomeService $service): User
+    {
+        return new User();
+    }
+}

--- a/tests/Rules/MissingImport/Fixture/EnumUsages.php
+++ b/tests/Rules/MissingImport/Fixture/EnumUsages.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport\Fixture;
+
+enum EnumUsages: string implements \App\Contracts\HasLabel
+{
+    case Active = 'active';
+
+    public function label(\App\Services\SomeService $service): \App\Models\User
+    {
+        return new \App\Models\User();
+    }
+}

--- a/tests/Rules/MissingImport/Fixture/ExceptionsFqcnUsages.php
+++ b/tests/Rules/MissingImport/Fixture/ExceptionsFqcnUsages.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport\Fixture;
+
+class ExceptionsFqcnUsages
+{
+    public function allowedClass(): void
+    {
+        $obj = new \App\Services\SomeService();
+    }
+
+    public function notAllowedClass(): void
+    {
+        $obj = new \App\Models\User();
+    }
+}

--- a/tests/Rules/MissingImport/Fixture/ExplicitFqcnUsages.php
+++ b/tests/Rules/MissingImport/Fixture/ExplicitFqcnUsages.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport\Fixture;
+
+class ExplicitFqcnUsages
+{
+    private \App\Models\User $property;
+
+    public function newExpression(): void
+    {
+        $obj = new \App\Services\SomeService();
+    }
+
+    public function staticCall(): void
+    {
+        \App\Services\SomeService::create();
+    }
+
+    public function parameterType(\App\Models\User $user): void {}
+
+    public function returnType(): \App\Models\User
+    {
+        return new \App\Models\User();
+    }
+
+    public function instanceofCheck(mixed $value): void
+    {
+        if ($value instanceof \App\Models\User) {
+        }
+    }
+
+    public function catchBlock(): void
+    {
+        try {
+        } catch (\App\Exceptions\CustomException $e) {
+        }
+    }
+}

--- a/tests/Rules/MissingImport/Fixture/GlobalNamespaceUsages.php
+++ b/tests/Rules/MissingImport/Fixture/GlobalNamespaceUsages.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport\Fixture;
+
+class GlobalNamespaceUsages
+{
+    public function globalClasses(): void
+    {
+        $obj = new \stdClass();
+        $dt = new \DateTime();
+        $e = new \Exception('error');
+    }
+}

--- a/tests/Rules/MissingImport/Fixture/ImportedUsages.php
+++ b/tests/Rules/MissingImport/Fixture/ImportedUsages.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport\Fixture;
+
+use App\Exceptions\CustomException;
+use App\Models\User;
+use App\Services\SomeService;
+use Exception;
+use stdClass;
+
+class ImportedUsages
+{
+    private User $property;
+
+    public function newExpression(): void
+    {
+        $obj = new SomeService();
+        $std = new stdClass();
+        $e = new Exception('error');
+    }
+
+    public function staticCall(): void
+    {
+        SomeService::create();
+    }
+
+    public function parameterType(User $user): void {}
+
+    public function returnType(): User
+    {
+        return new User();
+    }
+
+    public function instanceofCheck(mixed $value): void
+    {
+        if ($value instanceof User) {
+        }
+    }
+
+    public function catchBlock(): void
+    {
+        try {
+        } catch (CustomException $e) {
+        }
+    }
+}

--- a/tests/Rules/MissingImport/Fixture/TraitUseFqcnUsages.php
+++ b/tests/Rules/MissingImport/Fixture/TraitUseFqcnUsages.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport\Fixture;
+
+class TraitUseFqcnUsages
+{
+    use \App\Traits\SomeTrait;
+}

--- a/tests/Rules/MissingImport/Fixture/TraitUseImportedUsages.php
+++ b/tests/Rules/MissingImport/Fixture/TraitUseImportedUsages.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport\Fixture;
+
+use App\Traits\SomeTrait;
+
+class TraitUseImportedUsages
+{
+    use SomeTrait;
+}

--- a/tests/Rules/MissingImport/IgnoreGlobalTest.php
+++ b/tests/Rules/MissingImport/IgnoreGlobalTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\MissingImport;
+
+use Orrison\MeliorStan\Rules\MissingImport\MissingImportRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<MissingImportRule>
+ */
+class IgnoreGlobalTest extends RuleTestCase
+{
+    public function testGlobalNamespaceClassesAreIgnored(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/GlobalNamespaceUsages.php'],
+            []
+        );
+    }
+
+    public function testNonGlobalClassesAreStillFlagged(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ExplicitFqcnUsages.php'],
+            [
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 7],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Services\SomeService'), 11],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Services\SomeService'), 16],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 19],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 21],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 23],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Models\User'), 28],
+                [sprintf(MissingImportRule::ERROR_MESSAGE_TEMPLATE, 'App\Exceptions\CustomException'), 35],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignore_global.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(MissingImportRule::class);
+    }
+}

--- a/tests/Rules/MissingImport/config/default.neon
+++ b/tests/Rules/MissingImport/config/default.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\MissingImport\MissingImportRule
+
+parameters:
+    meliorstan:
+        missing_import:
+            ignore_global: false
+            exceptions: []

--- a/tests/Rules/MissingImport/config/exceptions.neon
+++ b/tests/Rules/MissingImport/config/exceptions.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\MissingImport\MissingImportRule
+
+parameters:
+    meliorstan:
+        missing_import:
+            ignore_global: false
+            exceptions:
+                - App\Services\SomeService

--- a/tests/Rules/MissingImport/config/ignore_global.neon
+++ b/tests/Rules/MissingImport/config/ignore_global.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\MissingImport\MissingImportRule
+
+parameters:
+    meliorstan:
+        missing_import:
+            ignore_global: true
+            exceptions: []


### PR DESCRIPTION
This pull request introduces a new PHPStan rule, `MissingImportRule`, which detects usages of fully qualified class names (FQCNs) in code and enforces importing them via `use` statements for better readability and maintainability. The rule is configurable, allowing exceptions and control over global namespace class handling. The PR also includes comprehensive documentation, configuration updates, and a full test suite to ensure correct behavior.

**New Rule: MissingImport**

*Rule implementation and configuration:*
- Added `MissingImportRule` (`src/Rules/MissingImport/MissingImportRule.php`) to flag explicit usages of FQCNs in type hints, expressions, class declarations, and more, unless imported via `use`. Includes logic for configuration and exception handling.
- Introduced `Config` class for `MissingImportRule` to handle `ignore_global` and `exceptions` options.
- Updated `config/extension.neon` to register the rule, provide parameter schema, and set default values for `ignore_global` and `exceptions`. [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R109-R112) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R201-R203) [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R339-R343)

*Documentation:*
- Added `docs/MissingImport.md` with a detailed explanation, configuration options, and usage examples for the new rule.
- Updated the `README.md` to include `MissingImport` in the list of available rules.

*Testing:*
- Added a suite of tests for default behavior, exception handling, and various code contexts in `tests/Rules/MissingImport/`, including fixtures for explicit FQCN usages, global namespace classes, enums, and exceptions. [[1]](diffhunk://#diff-4415e3c3a0a6b9e7fa5dfbb3024746cf389d6be724a8a250ac733ebb27902526R1-R81) [[2]](diffhunk://#diff-400c1ff70fa993f48e9041837742c825728e9faffd1f2c92ad3f8d24012cca59R1-R33) [[3]](diffhunk://#diff-1e2ce1c46336091e6a881b61dd3de4150a95c9df7f899596bc12e8cfea522830R1-R38) [[4]](diffhunk://#diff-daf6dda1ff452542f48a0e24cf213fbb75dd0b0bbdd20394381e79629cff709aR1-R13) [[5]](diffhunk://#diff-08d3d14a0dd1d5fb6eb6f2702d06386c94f4f6ff44187b8ee213338c35aaa3a1R1-R17) [[6]](diffhunk://#diff-646f24097db2a4f2599359bf3b5b17709c4a5f8b837e529ed66e347e17751e9dR1-R16) [[7]](diffhunk://#diff-e92ae4dc9683171274927f1f102704b7961970bd28a05db8cdcc45122c4d3e71R1-R13)
- Updated `php-cs-fixer.php` to exclude test fixtures for `MissingImport` from automatic import fixes.

Closes https://github.com/Orrison/MeliorStan/issues/34