### PR TITLE
Add ErrorControlOperator rule with documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ parameters:
 |------|-------------|---------|
 | **[DevelopmentCodeFragment](docs/DevelopmentCodeFragment.md)** | Detects calls to development/debug functions like var_dump, print_r, etc. | Function Calls |
 | **[EmptyCatchBlock](docs/EmptyCatchBlock.md)** | Detects and reports empty catch blocks in exception handling | Catch Blocks |
+| **[ErrorControlOperator](docs/ErrorControlOperator.md)** | Detects use of the error control operator (@), which silently suppresses errors instead of handling them properly | Error Suppression |
 | **[ForbidCountInLoopExpressions](docs/ForbidCountInLoopExpressions.md)** | Detects usage of count() or sizeof() in loop conditions | Loop Conditions |
 | **[ForbidEvalExpressions](docs/ForbidEvalExpressions.md)** | Detects and reports usage of eval expressions | Eval Expressions |
 | **[ForbidExitExpressions](docs/ForbidExitExpressions.md)** | Detects and reports usage of exit and die expressions | Exit Expressions |

--- a/docs/ErrorControlOperator.md
+++ b/docs/ErrorControlOperator.md
@@ -76,7 +76,7 @@ class Example
         try {
             $this->riskyOperation();
         } catch (\Throwable $e) {
-            // Handle or log the exception
+            throw new \RuntimeException('Operation failed.', 0, $e);
         }
     }
 }

--- a/docs/ErrorControlOperator.md
+++ b/docs/ErrorControlOperator.md
@@ -1,0 +1,89 @@
+# ErrorControlOperator
+
+Detects use of the error control operator (`@`) in PHP code.
+
+The `@` operator suppresses error messages from the expression it precedes. While PHP supports this operator, its use is considered a code smell because it silently hides errors rather than addressing them. Suppressed errors can mask bugs, make debugging difficult, and prevent proper error logging. The correct approach is to validate inputs, check return values, or use exception handling.
+
+## Configuration
+
+This rule has no configuration options.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ErrorControlOperator\ErrorControlOperatorRule
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class Example
+{
+    public function deleteFile(string $path): void
+    {
+        @unlink($path); // ✗ Error: Use of the error control operator (@) is not allowed.
+    }
+
+    public function openFile(string $path): mixed
+    {
+        return @fopen($path, 'r'); // ✗ Error: Use of the error control operator (@) is not allowed.
+    }
+
+    public function getArrayValue(array $data): mixed
+    {
+        return @$data['missing_key']; // ✗ Error: Use of the error control operator (@) is not allowed.
+    }
+
+    public function deleteFileProperly(string $path): void
+    {
+        // ✓ Valid - check before acting
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
+
+    public function openFileProperly(string $path): mixed
+    {
+        // ✓ Valid - check the return value explicitly
+        $handle = fopen($path, 'r');
+
+        if ($handle === false) {
+            return null;
+        }
+
+        return $handle;
+    }
+
+    public function getArrayValueProperly(array $data): mixed
+    {
+        // ✓ Valid - use null coalescing
+        return $data['missing_key'] ?? null;
+    }
+
+    public function riskyOperationProperly(): void
+    {
+        // ✓ Valid - use exception handling
+        try {
+            $this->riskyOperation();
+        } catch (\Throwable $e) {
+            // Handle or log the exception
+        }
+    }
+}
+```
+
+## Important Notes
+
+- This rule reports **all** uses of the `@` operator without exception
+- The `@` operator works on any expression, including function calls, variable accesses, array accesses, property accesses, and method calls — all are flagged
+- Consider using proper alternatives: input validation, return value checks, null coalescing (`??`), or `try`/`catch` blocks

--- a/src/Rules/ErrorControlOperator/ErrorControlOperatorRule.php
+++ b/src/Rules/ErrorControlOperator/ErrorControlOperatorRule.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ErrorControlOperator;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ErrorSuppress;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ErrorSuppress>
+ */
+class ErrorControlOperatorRule implements Rule
+{
+    public const string ERROR_MESSAGE = 'Use of the error control operator (@) is not allowed.';
+
+    public function getNodeType(): string
+    {
+        return ErrorSuppress::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                ->identifier('MeliorStan.errorControlOperatorUsed')
+                ->build(),
+        ];
+    }
+}

--- a/tests/Rules/ErrorControlOperator/ErrorControlOperatorTest.php
+++ b/tests/Rules/ErrorControlOperator/ErrorControlOperatorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ErrorControlOperator;
+
+use Orrison\MeliorStan\Rules\ErrorControlOperator\ErrorControlOperatorRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ErrorControlOperatorRule>
+ */
+class ErrorControlOperatorTest extends RuleTestCase
+{
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/config/test.neon',
+        ];
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ExampleWithErrors.php',
+                __DIR__ . '/Fixture/ExampleWithoutErrors.php',
+            ],
+            [
+                [ErrorControlOperatorRule::ERROR_MESSAGE, 12],
+                [ErrorControlOperatorRule::ERROR_MESSAGE, 19],
+                [ErrorControlOperatorRule::ERROR_MESSAGE, 26],
+                [ErrorControlOperatorRule::ERROR_MESSAGE, 33],
+            ]
+        );
+    }
+
+    protected function getRule(): Rule
+    {
+        return new ErrorControlOperatorRule();
+    }
+}

--- a/tests/Rules/ErrorControlOperator/Fixture/ExampleWithErrors.php
+++ b/tests/Rules/ErrorControlOperator/Fixture/ExampleWithErrors.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ErrorControlOperator\Fixture;
+
+use stdClass;
+
+class ExampleWithErrors
+{
+    public function suppressedFunctionCall(): void
+    {
+        $path = '/tmp/file.txt';
+        @unlink($path);
+    }
+
+    public function suppressedFileOpen(): mixed
+    {
+        $file = '/tmp/data.csv';
+
+        return @fopen($file, 'r');
+    }
+
+    public function suppressedArrayAccess(): mixed
+    {
+        $data = ['key' => 'value'];
+
+        return @$data['missing'];
+    }
+
+    public function suppressedMethodCall(): mixed
+    {
+        $obj = new stdClass();
+
+        return @$obj->nonExistentMethod();
+    }
+}

--- a/tests/Rules/ErrorControlOperator/Fixture/ExampleWithoutErrors.php
+++ b/tests/Rules/ErrorControlOperator/Fixture/ExampleWithoutErrors.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ErrorControlOperator\Fixture;
+
+use Throwable;
+
+class ExampleWithoutErrors
+{
+    public function properFileHandling(): void
+    {
+        $path = '/tmp/file.txt';
+
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
+
+    public function properFileOpen(): mixed
+    {
+        $file = '/tmp/data.csv';
+
+        $handle = fopen($file, 'r');
+
+        if ($handle === false) {
+            return null;
+        }
+
+        return $handle;
+    }
+
+    public function properArrayAccess(): mixed
+    {
+        $data = ['key' => 'value'];
+
+        return $data['missing'] ?? null;
+    }
+
+    public function properExceptionHandling(): void
+    {
+        try {
+            $this->riskyOperation();
+        } catch (Throwable $e) {
+            // Handle exception properly
+        }
+    }
+
+    protected function riskyOperation(): void
+    {
+        // Some operation
+    }
+}

--- a/tests/Rules/ErrorControlOperator/config/test.neon
+++ b/tests/Rules/ErrorControlOperator/config/test.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ErrorControlOperator\ErrorControlOperatorRule


### PR DESCRIPTION
This pull request introduces a new rule to detect and forbid the use of the PHP error control operator (`@`) across the codebase. The main goal is to prevent silent error suppression, encouraging proper error handling practices instead. The implementation includes the rule itself, comprehensive documentation, and a full suite of tests.

**New Error Control Operator Rule:**

*Rule Implementation:*
- Added `ErrorControlOperatorRule` to flag any use of the error control operator (`@`) in PHP code. The rule returns a clear error message and a unique identifier for each violation.

*Documentation:*
- Created `docs/ErrorControlOperator.md` to explain the rule's purpose, usage, configuration, and provide code examples of both violations and compliant alternatives.
- Updated the `README.md` parameters table to include the new rule and its description.

*Testing:*
- Added a test case `ErrorControlOperatorTest` that verifies the rule flags all uses of the `@` operator and ignores proper error handling.
- Provided fixture files with both violating and compliant code samples for thorough testing. [[1]](diffhunk://#diff-2dfe42cea98bf73f07fb8e76e7a37902054f882b697e6c6d3b99dc97429e8614R1-R35) [[2]](diffhunk://#diff-d87c6178784b95f5295d7b40fb12e8c49c45450f0fefcf34022f78e363d383a7R1-R51)
- Included a test configuration file to enable the rule during automated tests.

Closes https://github.com/Orrison/MeliorStan/issues/33