### PR TITLE
Add TooManyPublicMethods rule with configuration, documentation, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ parameters:
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |
 | **[StaticAccess](docs/StaticAccess.md)** | Detects static method calls and optionally static property access that create tight coupling | Static Access |
 | **[TooManyMethods](docs/TooManyMethods.md)** | Detects classes with too many methods | Classes, Interfaces, Traits, Enums |
+| **[TooManyPublicMethods](docs/TooManyPublicMethods.md)** | Detects classes with too many public methods | Classes, Interfaces, Traits, Enums |
 
 ### Already Covered by PHPStan
 

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -110,6 +110,11 @@ parametersSchema:
             ignore_global: bool(),
             exceptions: arrayOf(string()),
         ]),
+        too_many_public_methods: structure([
+            max_methods: int(),
+            ignore_pattern: string(),
+            ignore_magic_methods: bool(),
+        ]),
     ])
 
 # default parameters
@@ -201,6 +206,10 @@ parameters:
         missing_import:
             ignore_global: false
             exceptions: []
+        too_many_public_methods:
+            max_methods: 10
+            ignore_pattern: '^(get|set|is)'
+            ignore_magic_methods: true
 
 services:
     -
@@ -341,3 +350,9 @@ services:
         arguments:
             - %meliorstan.missing_import.ignore_global%
             - %meliorstan.missing_import.exceptions%
+    -
+        factory: Orrison\MeliorStan\Rules\TooManyPublicMethods\Config
+        arguments:
+            - %meliorstan.too_many_public_methods.max_methods%
+            - %meliorstan.too_many_public_methods.ignore_pattern%
+            - %meliorstan.too_many_public_methods.ignore_magic_methods%

--- a/docs/TooManyPublicMethods.md
+++ b/docs/TooManyPublicMethods.md
@@ -1,0 +1,181 @@
+# TooManyPublicMethods
+
+This rule checks if a class, interface, trait, or enum has too many public methods, which may indicate the class has an overly broad public API and should be refactored into smaller, more focused components.
+
+Based on the [PHPMD TooManyPublicMethods](https://phpmd.org/rules/codesize.html#toomanypublicmethods) rule.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `max_methods`
+- **Type**: `int`
+- **Default**: `10`
+- **Description**: The maximum number of public methods allowed in a class-like structure before triggering an error.
+
+### `ignore_pattern`
+- **Type**: `string`
+- **Default**: `^(get|set|is)`
+- **Description**: A regular expression pattern (without delimiters) to match public method names that should be excluded from the count. By default, getter, setter, and boolean accessor methods are ignored. Set to an empty string `''` to count all public methods.
+
+### `ignore_magic_methods`
+- **Type**: `bool`
+- **Default**: `true`
+- **Description**: When `true`, PHP magic methods (those starting with `__`, such as `__construct`, `__toString`, `__get`, etc.) are excluded from the public method count. Magic methods are PHP requirements rather than deliberate API choices, so they are ignored by default.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\TooManyPublicMethods\TooManyPublicMethodsRule
+
+parameters:
+    meliorstan:
+        too_many_public_methods:
+            max_methods: 10
+            ignore_pattern: '^(get|set|is)'
+            ignore_magic_methods: true
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class UserService
+{
+    public function __construct() {}      // ✓ Ignored (magic method)
+    public function getName(): string {}  // ✓ Ignored (matches ignore_pattern)
+    public function setName(string $name): void {}  // ✓ Ignored (matches ignore_pattern)
+    public function isActive(): bool {}   // ✓ Ignored (matches ignore_pattern)
+
+    // 10 regular public methods — at the limit, no error
+    public function register(): void {}
+    public function activate(): void {}
+    public function deactivate(): void {}
+    public function suspend(): void {}
+    public function delete(): void {}
+    public function restore(): void {}
+    public function sendWelcomeEmail(): void {}
+    public function sendPasswordReset(): void {}
+    public function generateToken(): string {}
+    public function revokeToken(): void {}
+}
+// ✓ Valid — exactly 10 counted methods
+
+class GodService
+{
+    public function processOrder(): void {}
+    public function cancelOrder(): void {}
+    public function refundOrder(): void {}
+    public function sendInvoice(): void {}
+    public function notifyCustomer(): void {}
+    public function updateInventory(): void {}
+    public function logActivity(): void {}
+    public function validatePayment(): void {}
+    public function chargeCard(): void {}
+    public function applyDiscount(): void {}
+    public function calculateTax(): void {}
+}
+// ✗ Error: Class "GodService" has 11 public methods, which exceeds the maximum of 10. Consider refactoring.
+```
+
+### Configuration Examples
+
+#### Count Magic Methods
+
+```neon
+parameters:
+    meliorstan:
+        too_many_public_methods:
+            ignore_magic_methods: false
+```
+
+```php
+<?php
+
+class Service
+{
+    public function __construct() {}   // Counted
+    public function __toString(): string {}  // Counted
+    public function methodOne(): void {}
+    public function methodTwo(): void {}
+    public function methodThree(): void {}
+    public function methodFour(): void {}
+    public function methodFive(): void {}
+    public function methodSix(): void {}
+    public function methodSeven(): void {}
+    public function methodEight(): void {}
+    public function methodNine(): void {}
+}
+// ✗ Error: Class "Service" has 11 public methods, which exceeds the maximum of 10. Consider refactoring.
+```
+
+#### Count All Public Methods (No Ignore Pattern)
+
+```neon
+parameters:
+    meliorstan:
+        too_many_public_methods:
+            ignore_pattern: ''
+```
+
+```php
+<?php
+
+class DataTransferObject
+{
+    public function getName(): string {}    // Counted (no pattern exclusion)
+    public function setName(string $n): void {}  // Counted
+    public function getEmail(): string {}   // Counted
+    public function setEmail(string $e): void {}  // Counted
+    public function getAge(): int {}        // Counted
+    public function setAge(int $a): void {} // Counted
+    public function isActive(): bool {}     // Counted
+    public function isVerified(): bool {}   // Counted
+    public function process(): void {}      // Counted
+    public function validate(): void {}     // Counted
+    public function execute(): void {}      // Counted
+}
+// ✗ Error: Class "DataTransferObject" has 11 public methods, which exceeds the maximum of 10. Consider refactoring.
+```
+
+#### Custom Ignore Pattern
+
+```neon
+parameters:
+    meliorstan:
+        too_many_public_methods:
+            ignore_pattern: '^(get|set|is|has|with|can)'
+```
+
+```php
+<?php
+
+class Builder
+{
+    public function withTimeout(int $t): self {}    // ✓ Ignored
+    public function withRetries(int $r): self {}    // ✓ Ignored
+    public function hasItems(): bool {}             // ✓ Ignored
+    public function canProcess(): bool {}           // ✓ Ignored
+    public function build(): object {}              // Counted
+}
+```
+
+## Important Notes
+
+- The rule applies to classes, interfaces, traits, and enums
+- Interface methods are always counted as public (interfaces are implicitly all-public)
+- Static public methods are counted the same as instance public methods
+- Protected and private methods are never counted
+- The `ignore_pattern` is case-insensitive (e.g., `GetName` and `getname` are both matched)
+- Pattern delimiters (`/`) are added automatically — only provide the pattern itself
+- Methods are counted based on their declaration in the specific class-like structure, not inherited methods
+- Consider using this rule alongside `TooManyMethods` to distinguish between all-method bloat and public API bloat

--- a/docs/TooManyPublicMethods.md
+++ b/docs/TooManyPublicMethods.md
@@ -51,10 +51,10 @@ parameters:
 
 class UserService
 {
-    public function __construct() {}      // ✓ Ignored (magic method)
-    public function getName(): string {}  // ✓ Ignored (matches ignore_pattern)
-    public function setName(string $name): void {}  // ✓ Ignored (matches ignore_pattern)
-    public function isActive(): bool {}   // ✓ Ignored (matches ignore_pattern)
+    public function __construct() {}                           // ✓ Ignored (magic method)
+    public function getName(): string { return ''; }          // ✓ Ignored (matches ignore_pattern)
+    public function setName(string $name): void {}            // ✓ Ignored (matches ignore_pattern)
+    public function isActive(): bool { return true; }         // ✓ Ignored (matches ignore_pattern)
 
     // 10 regular public methods — at the limit, no error
     public function register(): void {}
@@ -65,7 +65,7 @@ class UserService
     public function restore(): void {}
     public function sendWelcomeEmail(): void {}
     public function sendPasswordReset(): void {}
-    public function generateToken(): string {}
+    public function generateToken(): string { return ''; }
     public function revokeToken(): void {}
 }
 // ✓ Valid — exactly 10 counted methods
@@ -103,8 +103,8 @@ parameters:
 
 class Service
 {
-    public function __construct() {}   // Counted
-    public function __toString(): string {}  // Counted
+    public function __construct() {}                    // Counted
+    public function __toString(): string { return ''; } // Counted
     public function methodOne(): void {}
     public function methodTwo(): void {}
     public function methodThree(): void {}
@@ -132,17 +132,17 @@ parameters:
 
 class DataTransferObject
 {
-    public function getName(): string {}    // Counted (no pattern exclusion)
-    public function setName(string $n): void {}  // Counted
-    public function getEmail(): string {}   // Counted
-    public function setEmail(string $e): void {}  // Counted
-    public function getAge(): int {}        // Counted
-    public function setAge(int $a): void {} // Counted
-    public function isActive(): bool {}     // Counted
-    public function isVerified(): bool {}   // Counted
-    public function process(): void {}      // Counted
-    public function validate(): void {}     // Counted
-    public function execute(): void {}      // Counted
+    public function getName(): string { return ''; }   // Counted (no pattern exclusion)
+    public function setName(string $n): void {}        // Counted
+    public function getEmail(): string { return ''; }  // Counted
+    public function setEmail(string $e): void {}       // Counted
+    public function getAge(): int { return 0; }        // Counted
+    public function setAge(int $a): void {}            // Counted
+    public function isActive(): bool { return true; }  // Counted
+    public function isVerified(): bool { return false; } // Counted
+    public function process(): void {}                 // Counted
+    public function validate(): void {}                // Counted
+    public function execute(): void {}                 // Counted
 }
 // ✗ Error: Class "DataTransferObject" has 11 public methods, which exceeds the maximum of 10. Consider refactoring.
 ```
@@ -161,11 +161,11 @@ parameters:
 
 class Builder
 {
-    public function withTimeout(int $t): self {}    // ✓ Ignored
-    public function withRetries(int $r): self {}    // ✓ Ignored
-    public function hasItems(): bool {}             // ✓ Ignored
-    public function canProcess(): bool {}           // ✓ Ignored
-    public function build(): object {}              // Counted
+    public function withTimeout(int $t): self { return $this; }   // ✓ Ignored
+    public function withRetries(int $r): self { return $this; }  // ✓ Ignored
+    public function hasItems(): bool { return true; }            // ✓ Ignored
+    public function canProcess(): bool { return true; }          // ✓ Ignored
+    public function build(): object { return new \stdClass(); }  // Counted
 }
 ```
 

--- a/src/Rules/TooManyPublicMethods/Config.php
+++ b/src/Rules/TooManyPublicMethods/Config.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\TooManyPublicMethods;
+
+class Config
+{
+    public function __construct(
+        protected int $maxMethods = 10,
+        protected string $ignorePattern = '^(get|set|is)',
+        protected bool $ignoreMagicMethods = true,
+    ) {}
+
+    public function getMaxMethods(): int
+    {
+        return $this->maxMethods;
+    }
+
+    public function getIgnorePattern(): string
+    {
+        return $this->ignorePattern;
+    }
+
+    public function getIgnoreMagicMethods(): bool
+    {
+        return $this->ignoreMagicMethods;
+    }
+}

--- a/src/Rules/TooManyPublicMethods/TooManyPublicMethodsRule.php
+++ b/src/Rules/TooManyPublicMethods/TooManyPublicMethodsRule.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\TooManyPublicMethods;
+
+use InvalidArgumentException;
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Trait_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassLike>
+ */
+class TooManyPublicMethodsRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = '%s "%s" has %d public methods, which exceeds the maximum of %d. Consider refactoring.';
+
+    public function __construct(
+        protected Config $config,
+    ) {}
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassLike::class;
+    }
+
+    /**
+     * @param ClassLike $node
+     *
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        $publicMethodCount = $this->countPublicMethods($node);
+
+        if ($publicMethodCount <= $this->config->getMaxMethods()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    self::ERROR_MESSAGE_TEMPLATE,
+                    $this->getNodeTypeName($node),
+                    $node->name->toString(),
+                    $publicMethodCount,
+                    $this->config->getMaxMethods()
+                )
+            )
+                ->identifier('MeliorStan.tooManyPublicMethods')
+                ->build(),
+        ];
+    }
+
+    protected function countPublicMethods(ClassLike $node): int
+    {
+        $ignorePattern = $this->config->getIgnorePattern();
+        $ignoreMagicMethods = $this->config->getIgnoreMagicMethods();
+        $regex = $ignorePattern === '' ? null : '/' . $ignorePattern . '/i';
+        $isInterface = $node instanceof Interface_;
+        $count = 0;
+
+        foreach ($node->getMethods() as $method) {
+            // Interfaces are implicitly all-public; skip visibility check for them
+            if (! $isInterface && ! $method->isPublic()) {
+                continue;
+            }
+
+            $methodName = $method->name->toString();
+
+            if ($ignoreMagicMethods && str_starts_with($methodName, '__')) {
+                continue;
+            }
+
+            if ($regex !== null) {
+                $result = @preg_match($regex, $methodName);
+
+                if ($result === false || preg_last_error() !== PREG_NO_ERROR) {
+                    throw new InvalidArgumentException(
+                        sprintf(
+                            'Invalid regex pattern in ignore_pattern configuration: "%s". Error: %s',
+                            $ignorePattern,
+                            preg_last_error_msg()
+                        )
+                    );
+                }
+
+                if ($result === 1) {
+                    continue;
+                }
+            }
+
+            ++$count;
+        }
+
+        return $count;
+    }
+
+    protected function getNodeTypeName(ClassLike $node): string
+    {
+        if ($node instanceof Class_) {
+            return 'Class';
+        }
+
+        if ($node instanceof Interface_) {
+            return 'Interface';
+        }
+
+        if ($node instanceof Trait_) {
+            return 'Trait';
+        }
+
+        if ($node instanceof Enum_) {
+            return 'Enum';
+        }
+
+        return 'Class';
+    }
+}

--- a/tests/Rules/TooManyPublicMethods/CustomMaxTest.php
+++ b/tests/Rules/TooManyPublicMethods/CustomMaxTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods;
+
+use Orrison\MeliorStan\Rules\TooManyPublicMethods\TooManyPublicMethodsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<TooManyPublicMethodsRule>
+ */
+class CustomMaxTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ClassExceedingCustomLimit.php',
+            ],
+            [
+                [
+                    sprintf(TooManyPublicMethodsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassExceedingCustomLimit', 6, 5),
+                    6,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/custom_max.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(TooManyPublicMethodsRule::class);
+    }
+}

--- a/tests/Rules/TooManyPublicMethods/Fixture/ClassAtLimit.php
+++ b/tests/Rules/TooManyPublicMethods/Fixture/ClassAtLimit.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods\Fixture;
+
+// Exactly 10 plain public methods — should not trigger an error
+class ClassAtLimit
+{
+    public function methodOne(): void {}
+
+    public function methodTwo(): void {}
+
+    public function methodThree(): void {}
+
+    public function methodFour(): void {}
+
+    public function methodFive(): void {}
+
+    public function methodSix(): void {}
+
+    public function methodSeven(): void {}
+
+    public function methodEight(): void {}
+
+    public function methodNine(): void {}
+
+    public function methodTen(): void {}
+}

--- a/tests/Rules/TooManyPublicMethods/Fixture/ClassExceedingCustomLimit.php
+++ b/tests/Rules/TooManyPublicMethods/Fixture/ClassExceedingCustomLimit.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods\Fixture;
+
+// 6 plain public methods — exceeds a custom limit of 5
+class ClassExceedingCustomLimit
+{
+    public function methodOne(): void {}
+
+    public function methodTwo(): void {}
+
+    public function methodThree(): void {}
+
+    public function methodFour(): void {}
+
+    public function methodFive(): void {}
+
+    public function methodSix(): void {}
+}

--- a/tests/Rules/TooManyPublicMethods/Fixture/ClassExceedingLimit.php
+++ b/tests/Rules/TooManyPublicMethods/Fixture/ClassExceedingLimit.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods\Fixture;
+
+// 11 plain public methods (no get/set/is prefix) — should trigger an error
+class ClassExceedingLimit
+{
+    public function methodOne(): void {}
+
+    public function methodTwo(): void {}
+
+    public function methodThree(): void {}
+
+    public function methodFour(): void {}
+
+    public function methodFive(): void {}
+
+    public function methodSix(): void {}
+
+    public function methodSeven(): void {}
+
+    public function methodEight(): void {}
+
+    public function methodNine(): void {}
+
+    public function methodTen(): void {}
+
+    public function methodEleven(): void {}
+}

--- a/tests/Rules/TooManyPublicMethods/Fixture/ClassWithFewMethods.php
+++ b/tests/Rules/TooManyPublicMethods/Fixture/ClassWithFewMethods.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods\Fixture;
+
+// 3 plain public methods + getters/setters (ignored by default) — no error
+class ClassWithFewMethods
+{
+    public function process(): void {}
+
+    public function validate(): void {}
+
+    public function execute(): void {}
+
+    public function getName(): string
+    {
+        return '';
+    }
+
+    public function setName(string $name): void {}
+
+    public function isActive(): bool
+    {
+        return true;
+    }
+
+    protected function internalHelper(): void {}
+
+    private function privateMethod(): void {}
+}

--- a/tests/Rules/TooManyPublicMethods/Fixture/ClassWithGettersExceedingLimit.php
+++ b/tests/Rules/TooManyPublicMethods/Fixture/ClassWithGettersExceedingLimit.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods\Fixture;
+
+// 11 public methods including getters — exceeds limit when ignore_pattern is empty
+class ClassWithGettersExceedingLimit
+{
+    public function getName(): string
+    {
+        return '';
+    }
+
+    public function getEmail(): string
+    {
+        return '';
+    }
+
+    public function getAge(): int
+    {
+        return 0;
+    }
+
+    public function getAddress(): string
+    {
+        return '';
+    }
+
+    public function getPhone(): string
+    {
+        return '';
+    }
+
+    public function setName(string $name): void {}
+
+    public function setEmail(string $email): void {}
+
+    public function setAge(int $age): void {}
+
+    public function isActive(): bool
+    {
+        return true;
+    }
+
+    public function isVerified(): bool
+    {
+        return false;
+    }
+
+    public function process(): void {}
+}

--- a/tests/Rules/TooManyPublicMethods/Fixture/ClassWithMagicMethods.php
+++ b/tests/Rules/TooManyPublicMethods/Fixture/ClassWithMagicMethods.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods\Fixture;
+
+// 9 plain public methods + __construct + __toString — magic methods excluded, so no error (9 <= 10)
+class ClassWithMagicMethods
+{
+    public function __construct() {}
+
+    public function __toString(): string
+    {
+        return '';
+    }
+
+    public function methodOne(): void {}
+
+    public function methodTwo(): void {}
+
+    public function methodThree(): void {}
+
+    public function methodFour(): void {}
+
+    public function methodFive(): void {}
+
+    public function methodSix(): void {}
+
+    public function methodSeven(): void {}
+
+    public function methodEight(): void {}
+
+    public function methodNine(): void {}
+}

--- a/tests/Rules/TooManyPublicMethods/Fixture/ClassWithMagicMethodsExceedingLimit.php
+++ b/tests/Rules/TooManyPublicMethods/Fixture/ClassWithMagicMethodsExceedingLimit.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods\Fixture;
+
+// 9 plain public methods + __construct + __toString = 11 counted when magic methods are NOT excluded
+class ClassWithMagicMethodsExceedingLimit
+{
+    public function __construct() {}
+
+    public function __toString(): string
+    {
+        return '';
+    }
+
+    public function methodOne(): void {}
+
+    public function methodTwo(): void {}
+
+    public function methodThree(): void {}
+
+    public function methodFour(): void {}
+
+    public function methodFive(): void {}
+
+    public function methodSix(): void {}
+
+    public function methodSeven(): void {}
+
+    public function methodEight(): void {}
+
+    public function methodNine(): void {}
+}

--- a/tests/Rules/TooManyPublicMethods/Fixture/EnumExceedingLimit.php
+++ b/tests/Rules/TooManyPublicMethods/Fixture/EnumExceedingLimit.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods\Fixture;
+
+// 11 plain public methods — should trigger an error
+enum EnumExceedingLimit
+{
+    public function methodOne(): void {}
+
+    public function methodTwo(): void {}
+
+    public function methodThree(): void {}
+
+    public function methodFour(): void {}
+
+    public function methodFive(): void {}
+
+    public function methodSix(): void {}
+
+    public function methodSeven(): void {}
+
+    public function methodEight(): void {}
+
+    public function methodNine(): void {}
+
+    public function methodTen(): void {}
+
+    public function methodEleven(): void {}
+}

--- a/tests/Rules/TooManyPublicMethods/Fixture/InterfaceExceedingLimit.php
+++ b/tests/Rules/TooManyPublicMethods/Fixture/InterfaceExceedingLimit.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods\Fixture;
+
+// 11 methods (interfaces are implicitly all-public) — should trigger an error
+interface InterfaceExceedingLimit
+{
+    public function methodOne(): void;
+
+    public function methodTwo(): void;
+
+    public function methodThree(): void;
+
+    public function methodFour(): void;
+
+    public function methodFive(): void;
+
+    public function methodSix(): void;
+
+    public function methodSeven(): void;
+
+    public function methodEight(): void;
+
+    public function methodNine(): void;
+
+    public function methodTen(): void;
+
+    public function methodEleven(): void;
+}

--- a/tests/Rules/TooManyPublicMethods/Fixture/TraitExceedingLimit.php
+++ b/tests/Rules/TooManyPublicMethods/Fixture/TraitExceedingLimit.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods\Fixture;
+
+// 11 plain public methods — should trigger an error
+trait TraitExceedingLimit
+{
+    public function methodOne(): void {}
+
+    public function methodTwo(): void {}
+
+    public function methodThree(): void {}
+
+    public function methodFour(): void {}
+
+    public function methodFive(): void {}
+
+    public function methodSix(): void {}
+
+    public function methodSeven(): void {}
+
+    public function methodEight(): void {}
+
+    public function methodNine(): void {}
+
+    public function methodTen(): void {}
+
+    public function methodEleven(): void {}
+}

--- a/tests/Rules/TooManyPublicMethods/IgnoreMagicMethodsFalseTest.php
+++ b/tests/Rules/TooManyPublicMethods/IgnoreMagicMethodsFalseTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods;
+
+use Orrison\MeliorStan\Rules\TooManyPublicMethods\TooManyPublicMethodsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<TooManyPublicMethodsRule>
+ */
+class IgnoreMagicMethodsFalseTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ClassWithMagicMethodsExceedingLimit.php',
+                __DIR__ . '/Fixture/ClassWithMagicMethods.php',
+            ],
+            [
+                [
+                    sprintf(TooManyPublicMethodsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassWithMagicMethodsExceedingLimit', 11, 10),
+                    6,
+                ],
+                [
+                    sprintf(TooManyPublicMethodsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassWithMagicMethods', 11, 10),
+                    6,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignore_magic_methods_false.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(TooManyPublicMethodsRule::class);
+    }
+}

--- a/tests/Rules/TooManyPublicMethods/NoIgnorePatternTest.php
+++ b/tests/Rules/TooManyPublicMethods/NoIgnorePatternTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods;
+
+use Orrison\MeliorStan\Rules\TooManyPublicMethods\TooManyPublicMethodsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<TooManyPublicMethodsRule>
+ */
+class NoIgnorePatternTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ClassWithGettersExceedingLimit.php',
+            ],
+            [
+                [
+                    sprintf(TooManyPublicMethodsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassWithGettersExceedingLimit', 11, 10),
+                    6,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/no_ignore_pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(TooManyPublicMethodsRule::class);
+    }
+}

--- a/tests/Rules/TooManyPublicMethods/TooManyPublicMethodsRuleTest.php
+++ b/tests/Rules/TooManyPublicMethods/TooManyPublicMethodsRuleTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyPublicMethods;
+
+use Orrison\MeliorStan\Rules\TooManyPublicMethods\TooManyPublicMethodsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<TooManyPublicMethodsRule>
+ */
+class TooManyPublicMethodsRuleTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ClassExceedingLimit.php',
+                __DIR__ . '/Fixture/ClassAtLimit.php',
+                __DIR__ . '/Fixture/ClassWithFewMethods.php',
+                __DIR__ . '/Fixture/ClassWithMagicMethods.php',
+                __DIR__ . '/Fixture/TraitExceedingLimit.php',
+                __DIR__ . '/Fixture/InterfaceExceedingLimit.php',
+                __DIR__ . '/Fixture/EnumExceedingLimit.php',
+            ],
+            [
+                [
+                    sprintf(TooManyPublicMethodsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassExceedingLimit', 11, 10),
+                    6,
+                ],
+                [
+                    sprintf(TooManyPublicMethodsRule::ERROR_MESSAGE_TEMPLATE, 'Trait', 'TraitExceedingLimit', 11, 10),
+                    6,
+                ],
+                [
+                    sprintf(TooManyPublicMethodsRule::ERROR_MESSAGE_TEMPLATE, 'Interface', 'InterfaceExceedingLimit', 11, 10),
+                    6,
+                ],
+                [
+                    sprintf(TooManyPublicMethodsRule::ERROR_MESSAGE_TEMPLATE, 'Enum', 'EnumExceedingLimit', 11, 10),
+                    6,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(TooManyPublicMethodsRule::class);
+    }
+}

--- a/tests/Rules/TooManyPublicMethods/config/configured_rule.neon
+++ b/tests/Rules/TooManyPublicMethods/config/configured_rule.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\TooManyPublicMethods\TooManyPublicMethodsRule

--- a/tests/Rules/TooManyPublicMethods/config/custom_max.neon
+++ b/tests/Rules/TooManyPublicMethods/config/custom_max.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\TooManyPublicMethods\TooManyPublicMethodsRule
+
+parameters:
+    meliorstan:
+        too_many_public_methods:
+            max_methods: 5

--- a/tests/Rules/TooManyPublicMethods/config/ignore_magic_methods_false.neon
+++ b/tests/Rules/TooManyPublicMethods/config/ignore_magic_methods_false.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\TooManyPublicMethods\TooManyPublicMethodsRule
+
+parameters:
+    meliorstan:
+        too_many_public_methods:
+            ignore_magic_methods: false

--- a/tests/Rules/TooManyPublicMethods/config/no_ignore_pattern.neon
+++ b/tests/Rules/TooManyPublicMethods/config/no_ignore_pattern.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\TooManyPublicMethods\TooManyPublicMethodsRule
+
+parameters:
+    meliorstan:
+        too_many_public_methods:
+            ignore_pattern: ''


### PR DESCRIPTION
This pull request introduces a new PHPStan rule, `TooManyPublicMethods`, which detects classes, interfaces, traits, or enums with an excessive number of public methods. The rule is configurable and aims to help maintain a focused and manageable public API surface. The implementation includes configuration options, documentation, and comprehensive tests.

**New Rule: TooManyPublicMethods**

* Adds the `TooManyPublicMethods` rule to detect class-like structures with too many public methods, supporting configuration for maximum allowed methods, patterns to ignore (e.g., getters/setters), and whether to exclude magic methods. [[1]](diffhunk://#diff-3190480ca34928322bb3c184ed6ed3f01021ecf5ecba7150963dafb37952dedcR1-R133) [[2]](diffhunk://#diff-f9c17897fe2e1056b18fa51c035c8de191a09b1c14252e4e790226f60621c8d5R1-R27)

**Documentation**

* Introduces `docs/TooManyPublicMethods.md` with detailed usage instructions, configuration options, and examples for the new rule.
* Updates `README.md` to include the new rule in the parameters section.

**Configuration**

* Updates `config/extension.neon` to register the new rule, provide default parameters (`max_methods`, `ignore_pattern`, `ignore_magic_methods`), and wire up dependency injection for the rule's config. [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R113-R117) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R209-R212) [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R353-R358)

**Testing**

* Adds a suite of test fixtures and test cases covering various scenarios, including default and custom configurations, edge cases (e.g., magic methods, getter/setter patterns), and support for all class-like structures (classes, interfaces, enums, traits). [[1]](diffhunk://#diff-f9d7d4a0db5d3af9983be2f87f9ec98790c20c468502af853dc0ce4061929f1cR1-R29) [[2]](diffhunk://#diff-ef49661b43c26ca51de193240969a80006ac37f7c318b07cc7f0a82b6eaee9caR1-R29) [[3]](diffhunk://#diff-eb333c2835d9137e14ac3accce0b8924b302f503a9f030aea6e9352533dfe57aR1-R50) [[4]](diffhunk://#diff-71e6dd727c98b23a56e7d85fe1eb530abbe185c9238db8ecf2beec66ff5d3f2eR1-R32) [[5]](diffhunk://#diff-940f2d30e79e786464e899b6ceae665fc833d466ceef04c0a25938a38028d3d9R1-R32) [[6]](diffhunk://#diff-7569df66fc0dc482cdbdded914c3c121b50b7fbcf0c1c7c296945d45113d36b3R1-R27) [[7]](diffhunk://#diff-a2ace91d788fce2bcc2dc602000eab84c8c19903ad396b54b9f02e20cad3ba03R1-R19) [[8]](diffhunk://#diff-518f4884847c7e5e08a465a0267f3ba1823b930f18f68eb7a4ce66378a5196b8R1-R29) [[9]](diffhunk://#diff-b705f4409131eb681b52d01111469d65380717bb20a98db4109e59289b904d00R1-R29) [[10]](diffhunk://#diff-659a2f099a11cec3e3bcb9af0ef3d80dbcb1055d8f9b2792d8e5bb13c9aa562dR1-R41)

This addition helps enforce API surface discipline and offers flexibility to adapt to different coding standards and project needs.

Closes https://github.com/Orrison/MeliorStan/issues/45