### PR TITLE
Add TooManyFields rule with configuration, documentation, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ parameters:
 | **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |
 | **[StaticAccess](docs/StaticAccess.md)** | Detects static method calls and optionally static property access that create tight coupling | Static Access |
+| **[TooManyFields](docs/TooManyFields.md)** | Detects classes and traits with an excessive number of instance fields | Classes, Traits |
 | **[TooManyMethods](docs/TooManyMethods.md)** | Detects classes with too many methods | Classes, Interfaces, Traits, Enums |
 | **[TooManyPublicMethods](docs/TooManyPublicMethods.md)** | Detects classes with too many public methods | Classes, Interfaces, Traits, Enums |
 

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -115,6 +115,10 @@ parametersSchema:
             ignore_pattern: string(),
             ignore_magic_methods: bool(),
         ]),
+        too_many_fields: structure([
+            max_fields: int(),
+            ignore_static_properties: bool(),
+        ]),
     ])
 
 # default parameters
@@ -210,6 +214,9 @@ parameters:
             max_methods: 10
             ignore_pattern: '^(get|set|is)'
             ignore_magic_methods: true
+        too_many_fields:
+            max_fields: 15
+            ignore_static_properties: true
 
 services:
     -
@@ -356,3 +363,8 @@ services:
             - %meliorstan.too_many_public_methods.max_methods%
             - %meliorstan.too_many_public_methods.ignore_pattern%
             - %meliorstan.too_many_public_methods.ignore_magic_methods%
+    -
+        factory: Orrison\MeliorStan\Rules\TooManyFields\Config
+        arguments:
+            - %meliorstan.too_many_fields.max_fields%
+            - %meliorstan.too_many_fields.ignore_static_properties%

--- a/docs/TooManyFields.md
+++ b/docs/TooManyFields.md
@@ -104,7 +104,7 @@ class Registry
     public static bool $booted = false;     // Counted
 
     public string $fieldOne = '';
-    // ... 13 more instance fields
+    // ... 12 more instance fields
 }
 // ✗ Error: Class "Registry" has 16 fields, which exceeds the maximum of 15. Consider refactoring.
 ```

--- a/docs/TooManyFields.md
+++ b/docs/TooManyFields.md
@@ -1,0 +1,147 @@
+# TooManyFields
+
+This rule checks if a class or trait has too many instance fields (properties), which may indicate the class has taken on too many responsibilities and should be refactored into smaller, more focused components.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `max_fields`
+- **Type**: `int`
+- **Default**: `15`
+- **Description**: The maximum number of fields allowed in a class or trait before triggering an error.
+
+### `ignore_static_properties`
+- **Type**: `bool`
+- **Default**: `true`
+- **Description**: When `true`, static properties are excluded from the field count. Static properties are typically shared state or registries rather than per-instance data, so they are ignored by default.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\TooManyFields\TooManyFieldsRule
+
+parameters:
+    meliorstan:
+        too_many_fields:
+            max_fields: 15
+            ignore_static_properties: true
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class UserProfile
+{
+    public string $firstName = '';
+    public string $lastName = '';
+    public string $email = '';
+    public string $phone = '';
+    public string $addressLine1 = '';
+    public string $addressLine2 = '';
+    public string $city = '';
+    public string $state = '';
+    public string $postalCode = '';
+    public string $country = '';
+    public string $avatarUrl = '';
+    public string $bio = '';
+    public bool $isActive = true;
+    public bool $isVerified = false;
+    public string $timezone = '';
+}
+// ✓ Valid — exactly 15 fields
+
+class GodObject
+{
+    public string $firstName = '';
+    public string $lastName = '';
+    public string $email = '';
+    public string $phone = '';
+    public string $addressLine1 = '';
+    public string $addressLine2 = '';
+    public string $city = '';
+    public string $state = '';
+    public string $postalCode = '';
+    public string $country = '';
+    public string $avatarUrl = '';
+    public string $bio = '';
+    public bool $isActive = true;
+    public bool $isVerified = false;
+    public string $timezone = '';
+    public string $preferredLanguage = '';
+}
+// ✗ Error: Class "GodObject" has 16 fields, which exceeds the maximum of 15. Consider refactoring.
+```
+
+### Configuration Examples
+
+#### Count Static Properties
+
+```neon
+parameters:
+    meliorstan:
+        too_many_fields:
+            ignore_static_properties: false
+```
+
+```php
+<?php
+
+class Registry
+{
+    public static string $connection = '';   // Counted
+    public static int $instanceCount = 0;   // Counted
+    public static bool $booted = false;     // Counted
+
+    public string $fieldOne = '';
+    // ... 13 more instance fields
+}
+// ✗ Error: Class "Registry" has 16 fields, which exceeds the maximum of 15. Consider refactoring.
+```
+
+#### Lower Maximum for Stricter Codebases
+
+```neon
+parameters:
+    meliorstan:
+        too_many_fields:
+            max_fields: 10
+```
+
+```php
+<?php
+
+class ProductData
+{
+    public string $name = '';
+    public string $sku = '';
+    public float $price = 0.0;
+    public int $stock = 0;
+    public string $category = '';
+    public string $description = '';
+    public string $imageUrl = '';
+    public bool $isActive = true;
+    public string $brand = '';
+    public string $supplier = '';
+    public string $barcode = '';   // 11th field
+}
+// ✗ Error: Class "ProductData" has 11 fields, which exceeds the maximum of 10. Consider refactoring.
+```
+
+## Important Notes
+
+- The rule applies to classes and traits; interfaces and enums are always skipped
+- Only fields declared directly in the class or trait are counted — inherited fields are not included
+- Compound property declarations (`public string $a, $b, $c;`) count as multiple fields (one per variable)
+- Constructor-promoted properties are counted like any other instance property
+- Consider pairing this rule with [ExcessivePublicCount](ExcessivePublicCount.md) to also limit the total public API surface

--- a/src/Rules/TooManyFields/Config.php
+++ b/src/Rules/TooManyFields/Config.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\TooManyFields;
+
+class Config
+{
+    public function __construct(
+        protected int $maxFields = 15,
+        protected bool $ignoreStaticProperties = true,
+    ) {}
+
+    public function getMaxFields(): int
+    {
+        return $this->maxFields;
+    }
+
+    public function getIgnoreStaticProperties(): bool
+    {
+        return $this->ignoreStaticProperties;
+    }
+}

--- a/src/Rules/TooManyFields/TooManyFieldsRule.php
+++ b/src/Rules/TooManyFields/TooManyFieldsRule.php
@@ -5,6 +5,7 @@ namespace Orrison\MeliorStan\Rules\TooManyFields;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Property;
@@ -74,15 +75,23 @@ class TooManyFieldsRule implements Rule
         $count = 0;
 
         foreach ($node->stmts as $stmt) {
-            if (! $stmt instanceof Property) {
+            if ($stmt instanceof Property) {
+                if ($this->config->getIgnoreStaticProperties() && $stmt->isStatic()) {
+                    continue;
+                }
+
+                $count += count($stmt->props);
+
                 continue;
             }
 
-            if ($this->config->getIgnoreStaticProperties() && $stmt->isStatic()) {
-                continue;
+            if ($stmt instanceof ClassMethod && $stmt->name->toString() === '__construct') {
+                foreach ($stmt->params as $param) {
+                    if ($param->flags !== 0) {
+                        ++$count;
+                    }
+                }
             }
-
-            $count += count($stmt->props);
         }
 
         return $count;

--- a/src/Rules/TooManyFields/TooManyFieldsRule.php
+++ b/src/Rules/TooManyFields/TooManyFieldsRule.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\TooManyFields;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Trait_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassLike>
+ */
+class TooManyFieldsRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = '%s "%s" has %d fields, which exceeds the maximum of %d. Consider refactoring.';
+
+    public function __construct(
+        protected Config $config,
+    ) {}
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassLike::class;
+    }
+
+    /**
+     * @param ClassLike $node
+     *
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        if ($node instanceof Interface_ || $node instanceof Enum_) {
+            return [];
+        }
+
+        $fieldCount = $this->countFields($node);
+
+        if ($fieldCount <= $this->config->getMaxFields()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    self::ERROR_MESSAGE_TEMPLATE,
+                    $this->getNodeTypeName($node),
+                    $node->name->toString(),
+                    $fieldCount,
+                    $this->config->getMaxFields()
+                )
+            )
+                ->identifier('MeliorStan.tooManyFields')
+                ->build(),
+        ];
+    }
+
+    protected function countFields(ClassLike $node): int
+    {
+        $count = 0;
+
+        foreach ($node->stmts as $stmt) {
+            if (! $stmt instanceof Property) {
+                continue;
+            }
+
+            if ($this->config->getIgnoreStaticProperties() && $stmt->isStatic()) {
+                continue;
+            }
+
+            $count += count($stmt->props);
+        }
+
+        return $count;
+    }
+
+    protected function getNodeTypeName(ClassLike $node): string
+    {
+        if ($node instanceof Trait_) {
+            return 'Trait';
+        }
+
+        return 'Class';
+    }
+}

--- a/tests/Rules/TooManyFields/CustomMaxTest.php
+++ b/tests/Rules/TooManyFields/CustomMaxTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields;
+
+use Orrison\MeliorStan\Rules\TooManyFields\TooManyFieldsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<TooManyFieldsRule>
+ */
+class CustomMaxTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ClassExceedingCustomLimit.php',
+            ],
+            [
+                [
+                    sprintf(TooManyFieldsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassExceedingCustomLimit', 6, 5),
+                    6,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/custom_max.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(TooManyFieldsRule::class);
+    }
+}

--- a/tests/Rules/TooManyFields/Fixture/ClassAtLimit.php
+++ b/tests/Rules/TooManyFields/Fixture/ClassAtLimit.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields\Fixture;
+
+// Exactly 15 instance fields — should not trigger an error
+class ClassAtLimit
+{
+    public string $fieldOne = '';
+
+    public string $fieldTwo = '';
+
+    public string $fieldThree = '';
+
+    public string $fieldFour = '';
+
+    public string $fieldFive = '';
+
+    public string $fieldSix = '';
+
+    public string $fieldSeven = '';
+
+    public string $fieldEight = '';
+
+    public string $fieldNine = '';
+
+    public string $fieldTen = '';
+
+    public string $fieldEleven = '';
+
+    public string $fieldTwelve = '';
+
+    public string $fieldThirteen = '';
+
+    public string $fieldFourteen = '';
+
+    public string $fieldFifteen = '';
+}

--- a/tests/Rules/TooManyFields/Fixture/ClassExceedingCustomLimit.php
+++ b/tests/Rules/TooManyFields/Fixture/ClassExceedingCustomLimit.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields\Fixture;
+
+// 6 instance fields — exceeds a custom max of 5
+class ClassExceedingCustomLimit
+{
+    public string $fieldOne = '';
+
+    public string $fieldTwo = '';
+
+    public string $fieldThree = '';
+
+    public string $fieldFour = '';
+
+    public string $fieldFive = '';
+
+    public string $fieldSix = '';
+}

--- a/tests/Rules/TooManyFields/Fixture/ClassExceedingLimit.php
+++ b/tests/Rules/TooManyFields/Fixture/ClassExceedingLimit.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields\Fixture;
+
+// 16 instance fields — should trigger an error (max is 15)
+class ClassExceedingLimit
+{
+    public string $fieldOne = '';
+
+    public string $fieldTwo = '';
+
+    public string $fieldThree = '';
+
+    public string $fieldFour = '';
+
+    public string $fieldFive = '';
+
+    public string $fieldSix = '';
+
+    public string $fieldSeven = '';
+
+    public string $fieldEight = '';
+
+    public string $fieldNine = '';
+
+    public string $fieldTen = '';
+
+    public string $fieldEleven = '';
+
+    public string $fieldTwelve = '';
+
+    public string $fieldThirteen = '';
+
+    public string $fieldFourteen = '';
+
+    public string $fieldFifteen = '';
+
+    public string $fieldSixteen = '';
+}

--- a/tests/Rules/TooManyFields/Fixture/ClassWithFewFields.php
+++ b/tests/Rules/TooManyFields/Fixture/ClassWithFewFields.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields\Fixture;
+
+// Only 3 instance fields — well within the limit
+class ClassWithFewFields
+{
+    public string $name = '';
+
+    public string $email = '';
+
+    public int $age = 0;
+}

--- a/tests/Rules/TooManyFields/Fixture/ClassWithPromotedProperties.php
+++ b/tests/Rules/TooManyFields/Fixture/ClassWithPromotedProperties.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields\Fixture;
+
+// 16 promoted constructor properties — should trigger an error (max is 15)
+class ClassWithPromotedProperties
+{
+    public function __construct(
+        public string $fieldOne = '',
+        public string $fieldTwo = '',
+        public string $fieldThree = '',
+        public string $fieldFour = '',
+        public string $fieldFive = '',
+        public string $fieldSix = '',
+        public string $fieldSeven = '',
+        public string $fieldEight = '',
+        public string $fieldNine = '',
+        public string $fieldTen = '',
+        public string $fieldEleven = '',
+        public string $fieldTwelve = '',
+        public string $fieldThirteen = '',
+        public string $fieldFourteen = '',
+        public string $fieldFifteen = '',
+        public string $fieldSixteen = '',
+    ) {}
+}

--- a/tests/Rules/TooManyFields/Fixture/ClassWithStaticFields.php
+++ b/tests/Rules/TooManyFields/Fixture/ClassWithStaticFields.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields\Fixture;
+
+// 14 instance fields + 3 static fields = 17 total
+// With ignore_static_properties: true (default) → 14 counted → no error
+// With ignore_static_properties: false → 17 counted → error
+class ClassWithStaticFields
+{
+    public static string $registry = '';
+
+    public static int $instanceCount = 0;
+
+    public static bool $booted = false;
+
+    public string $fieldOne = '';
+
+    public string $fieldTwo = '';
+
+    public string $fieldThree = '';
+
+    public string $fieldFour = '';
+
+    public string $fieldFive = '';
+
+    public string $fieldSix = '';
+
+    public string $fieldSeven = '';
+
+    public string $fieldEight = '';
+
+    public string $fieldNine = '';
+
+    public string $fieldTen = '';
+
+    public string $fieldEleven = '';
+
+    public string $fieldTwelve = '';
+
+    public string $fieldThirteen = '';
+
+    public string $fieldFourteen = '';
+}

--- a/tests/Rules/TooManyFields/Fixture/InterfaceWithConstants.php
+++ b/tests/Rules/TooManyFields/Fixture/InterfaceWithConstants.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields\Fixture;
+
+// Interfaces have no instance fields — should never trigger
+interface InterfaceWithConstants
+{
+    public const string STATUS_ACTIVE = 'active';
+
+    public const string STATUS_INACTIVE = 'inactive';
+
+    public const string STATUS_PENDING = 'pending';
+
+    public function process(): void;
+}

--- a/tests/Rules/TooManyFields/Fixture/TraitAtLimit.php
+++ b/tests/Rules/TooManyFields/Fixture/TraitAtLimit.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields\Fixture;
+
+// Exactly 15 instance fields in a trait — should not trigger an error
+trait TraitAtLimit
+{
+    public string $fieldOne = '';
+
+    public string $fieldTwo = '';
+
+    public string $fieldThree = '';
+
+    public string $fieldFour = '';
+
+    public string $fieldFive = '';
+
+    public string $fieldSix = '';
+
+    public string $fieldSeven = '';
+
+    public string $fieldEight = '';
+
+    public string $fieldNine = '';
+
+    public string $fieldTen = '';
+
+    public string $fieldEleven = '';
+
+    public string $fieldTwelve = '';
+
+    public string $fieldThirteen = '';
+
+    public string $fieldFourteen = '';
+
+    public string $fieldFifteen = '';
+}

--- a/tests/Rules/TooManyFields/Fixture/TraitExceedingLimit.php
+++ b/tests/Rules/TooManyFields/Fixture/TraitExceedingLimit.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields\Fixture;
+
+// 16 instance fields in a trait — should trigger an error (max is 15)
+trait TraitExceedingLimit
+{
+    public string $fieldOne = '';
+
+    public string $fieldTwo = '';
+
+    public string $fieldThree = '';
+
+    public string $fieldFour = '';
+
+    public string $fieldFive = '';
+
+    public string $fieldSix = '';
+
+    public string $fieldSeven = '';
+
+    public string $fieldEight = '';
+
+    public string $fieldNine = '';
+
+    public string $fieldTen = '';
+
+    public string $fieldEleven = '';
+
+    public string $fieldTwelve = '';
+
+    public string $fieldThirteen = '';
+
+    public string $fieldFourteen = '';
+
+    public string $fieldFifteen = '';
+
+    public string $fieldSixteen = '';
+}

--- a/tests/Rules/TooManyFields/IncludeStaticPropertiesTest.php
+++ b/tests/Rules/TooManyFields/IncludeStaticPropertiesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields;
+
+use Orrison\MeliorStan\Rules\TooManyFields\TooManyFieldsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<TooManyFieldsRule>
+ */
+class IncludeStaticPropertiesTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ClassWithStaticFields.php',
+            ],
+            [
+                [
+                    sprintf(TooManyFieldsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassWithStaticFields', 17, 15),
+                    8,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/include_static_properties.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(TooManyFieldsRule::class);
+    }
+}

--- a/tests/Rules/TooManyFields/TooManyFieldsRuleTest.php
+++ b/tests/Rules/TooManyFields/TooManyFieldsRuleTest.php
@@ -19,6 +19,7 @@ class TooManyFieldsRuleTest extends RuleTestCase
                 __DIR__ . '/Fixture/ClassAtLimit.php',
                 __DIR__ . '/Fixture/ClassWithFewFields.php',
                 __DIR__ . '/Fixture/ClassWithStaticFields.php',
+                __DIR__ . '/Fixture/ClassWithPromotedProperties.php',
                 __DIR__ . '/Fixture/TraitExceedingLimit.php',
                 __DIR__ . '/Fixture/TraitAtLimit.php',
                 __DIR__ . '/Fixture/InterfaceWithConstants.php',
@@ -26,6 +27,10 @@ class TooManyFieldsRuleTest extends RuleTestCase
             [
                 [
                     sprintf(TooManyFieldsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassExceedingLimit', 16, 15),
+                    6,
+                ],
+                [
+                    sprintf(TooManyFieldsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassWithPromotedProperties', 16, 15),
                     6,
                 ],
                 [

--- a/tests/Rules/TooManyFields/TooManyFieldsRuleTest.php
+++ b/tests/Rules/TooManyFields/TooManyFieldsRuleTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\TooManyFields;
+
+use Orrison\MeliorStan\Rules\TooManyFields\TooManyFieldsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<TooManyFieldsRule>
+ */
+class TooManyFieldsRuleTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ClassExceedingLimit.php',
+                __DIR__ . '/Fixture/ClassAtLimit.php',
+                __DIR__ . '/Fixture/ClassWithFewFields.php',
+                __DIR__ . '/Fixture/ClassWithStaticFields.php',
+                __DIR__ . '/Fixture/TraitExceedingLimit.php',
+                __DIR__ . '/Fixture/TraitAtLimit.php',
+                __DIR__ . '/Fixture/InterfaceWithConstants.php',
+            ],
+            [
+                [
+                    sprintf(TooManyFieldsRule::ERROR_MESSAGE_TEMPLATE, 'Class', 'ClassExceedingLimit', 16, 15),
+                    6,
+                ],
+                [
+                    sprintf(TooManyFieldsRule::ERROR_MESSAGE_TEMPLATE, 'Trait', 'TraitExceedingLimit', 16, 15),
+                    6,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(TooManyFieldsRule::class);
+    }
+}

--- a/tests/Rules/TooManyFields/config/configured_rule.neon
+++ b/tests/Rules/TooManyFields/config/configured_rule.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\TooManyFields\TooManyFieldsRule

--- a/tests/Rules/TooManyFields/config/custom_max.neon
+++ b/tests/Rules/TooManyFields/config/custom_max.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\TooManyFields\TooManyFieldsRule
+
+parameters:
+    meliorstan:
+        too_many_fields:
+            max_fields: 5

--- a/tests/Rules/TooManyFields/config/include_static_properties.neon
+++ b/tests/Rules/TooManyFields/config/include_static_properties.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\TooManyFields\TooManyFieldsRule
+
+parameters:
+    meliorstan:
+        too_many_fields:
+            ignore_static_properties: false


### PR DESCRIPTION
This pull request introduces a new rule, `TooManyFields`, to the codebase. This rule detects classes and traits with an excessive number of instance fields, helping to enforce better design by encouraging smaller, more focused components. The implementation includes configuration options, documentation, and comprehensive tests to ensure correct behavior.

**Key changes:**

### Rule Implementation

* Added the `TooManyFieldsRule` class, which checks for classes and traits exceeding a configurable maximum number of fields, with the option to ignore static properties. (`src/Rules/TooManyFields/TooManyFieldsRule.php` [src/Rules/TooManyFields/TooManyFieldsRule.phpR1-R99](diffhunk://#diff-ca3f6353a16224011d49c7b757d85829bd1d695456278257d451a16b7fc1c964R1-R99))
* Introduced the corresponding configuration class, `Config`, to manage rule options (`maxFields`, `ignoreStaticProperties`). (`src/Rules/TooManyFields/Config.php` [src/Rules/TooManyFields/Config.phpR1-R21](diffhunk://#diff-79cda0f9efabaa1dfeb3dd98a3cffab1847d67f1b7af881eff485b088dedac5aR1-R21))

### Configuration

* Registered the new rule and its configuration structure in `extension.neon`, including default values and parameter schema. (`config/extension.neon` [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R118-R121) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R217-R219) [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R366-R370)
* Updated the main documentation table to include the new rule. (`README.md` [README.mdR130](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R130))

### Documentation

* Added a comprehensive documentation file for the rule, explaining configuration, usage, and examples. (`docs/TooManyFields.md` [docs/TooManyFields.mdR1-R147](diffhunk://#diff-5a0ed61a0cb75b452d056b8f039b9693f7b092a03be2af49aff64bca46709d24R1-R147))

### Testing

* Implemented extensive test coverage, including fixtures for various scenarios (at limit, exceeding limit, with static fields, traits, interfaces) and configuration variations (custom max, include static properties). (`tests/Rules/TooManyFields/` [[1]](diffhunk://#diff-d404ac792a9ed2cd8513a6f76f27aff814f27d06a5b430357cd82648165eb89fR1-R51) [[2]](diffhunk://#diff-a74caf29156306390c79eca1ba37914e96c545b01df34c95f4a3f9f3bf9d65c9R1-R37) [[3]](diffhunk://#diff-fa27f842a649c9cc441622c8b8acbd60066c74d87b84fa35e15d5e811d7e61c3R1-R39) [[4]](diffhunk://#diff-b99efdc85cf57a65f1b287f686b0f612f7111e72d5fd02f0d7d31a0d5e514deaR1-R13) [[5]](diffhunk://#diff-d0b893b79f5415a2d3f335ccc63b199d67babdbf6ad0df5e1eb5bf087e18048bR1-R43) [[6]](diffhunk://#diff-da2495200fc651f978be6e20fc9d5473e3d20c8577128952f8f77a771f2c16a1R1-R19) [[7]](diffhunk://#diff-5fd13af3307e55d004fbdb1b56c76b75319b515d341cdb4c0a652fc901d27ea6R1-R37) [[8]](diffhunk://#diff-640184f463ce09b322b240a02545a1f01401da4b7bbf96dc61711a6a905e6023R1-R15) [[9]](diffhunk://#diff-e4cb177f75fa16501e1fa6361dae3fb78990c2c3e5ac4a042d3af5b624957ddcR1-R41) [[10]](diffhunk://#diff-e61b46ebfeca19d16a280d74629e6334cd86c03f0cc5aa7551d26b9e4b936305R1-R10) [[11]](diffhunk://#diff-6454cfc7de12ea1df0da3f637f9d199ee74e97a55e8df60222ff7aef6deef8c8R1-R10) [[12]](diffhunk://#diff-4f66132968dbd8f86ba798f8dc7d7f91c7d23bd0cf6975c5e86f0ecf80e2c288R1-R5)

---

This addition helps teams prevent "god classes" and maintainable code by enforcing field count limits on classes and traits.

Closes https://github.com/Orrison/MeliorStan/issues/43