### PR TITLE
Add ExcessiveMethodLength rule with configuration, documentation, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ parameters:
 | **[ForbidGotoStatements](docs/ForbidGotoStatements.md)** | Detects and reports usage of goto statements | Goto Statements |
 | **[CouplingBetweenObjects](docs/CouplingBetweenObjects.md)** | Detects classes with too many type dependencies | Classes, Interfaces, Traits, Enums |
 | **[DepthOfInheritance](docs/DepthOfInheritance.md)** | Detects classes with excessively deep inheritance chains | Classes |
+| **[ExcessiveMethodLength](docs/ExcessiveMethodLength.md)** | Detects methods, functions, and closures with excessive line counts | Methods, Functions, Closures |
 | **[ExcessivePublicCount](docs/ExcessivePublicCount.md)** | Detects classes with an excessive public API surface (public methods + properties) | Classes, Interfaces, Traits, Enums |
 | **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -119,6 +119,11 @@ parametersSchema:
             max_fields: int(),
             ignore_static_properties: bool(),
         ]),
+        excessive_method_length: structure([
+            maximum: int(),
+            ignore_whitespace: bool(),
+            ignore_pattern: string(),
+        ]),
     ])
 
 # default parameters
@@ -217,6 +222,10 @@ parameters:
         too_many_fields:
             max_fields: 15
             ignore_static_properties: true
+        excessive_method_length:
+            maximum: 100
+            ignore_whitespace: false
+            ignore_pattern: ''
 
 services:
     -
@@ -368,3 +377,9 @@ services:
         arguments:
             - %meliorstan.too_many_fields.max_fields%
             - %meliorstan.too_many_fields.ignore_static_properties%
+    -
+        factory: Orrison\MeliorStan\Rules\ExcessiveMethodLength\Config
+        arguments:
+            - %meliorstan.excessive_method_length.maximum%
+            - %meliorstan.excessive_method_length.ignore_whitespace%
+            - %meliorstan.excessive_method_length.ignore_pattern%

--- a/docs/ExcessiveMethodLength.md
+++ b/docs/ExcessiveMethodLength.md
@@ -1,0 +1,165 @@
+# ExcessiveMethodLength
+
+This rule detects methods, functions, and closures whose line count exceeds a configurable threshold. Excessively long methods are usually a sign that the code is doing too much and should be broken into smaller, more focused units.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `maximum`
+- **Type**: `int`
+- **Default**: `100`
+- **Description**: The maximum number of lines a method, function, or closure may have before the rule reports an error. Lines are counted from the first line of the declaration through the closing brace of the body, inclusive.
+
+### `ignore_whitespace`
+- **Type**: `bool`
+- **Default**: `false`
+- **Description**: When `true`, blank lines and comment-only lines (single-line `//`, `#`, and docblock/`/* */` lines) are excluded from the line count. Useful for codebases that prefer the "effective lines of code" metric over raw line totals.
+
+### `ignore_pattern`
+- **Type**: `string`
+- **Default**: `''`
+- **Description**: A regular expression pattern (without delimiters) matched against method or function names. When a name matches, the declaration is skipped. Useful for methods that legitimately need to be long, such as Laravel migrations (`up`, `down`), seeders (`run`), service providers (`boot`, `register`), or form request `rules`. Set to an empty string to apply the rule to all names. Closures have no name and are never ignored by this option.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveMethodLength\ExcessiveMethodLengthRule
+
+parameters:
+    meliorstan:
+        excessive_method_length:
+            maximum: 100
+            ignore_whitespace: false
+            ignore_pattern: ''
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class OrderProcessor
+{
+    public function processOrder(Order $order): void
+    {
+        // ... 120 lines of validation, persistence, and side-effects ...
+    }
+    // ✗ Error: Method "processOrder" has 120 lines, which exceeds the maximum of 100. Consider refactoring.
+
+    public function findById(int $id): ?Order
+    {
+        return $this->repository->find($id);
+    }
+    // ✓ Valid - 4 lines
+}
+
+function buildReport(array $rows): string
+{
+    // ... 110 lines ...
+}
+// ✗ Error: Function "buildReport" has 110 lines, which exceeds the maximum of 100. Consider refactoring.
+
+$callback = function (Request $request) {
+    // ... 105 lines ...
+};
+// ✗ Error: Closure has 105 lines, which exceeds the maximum of 100. Consider refactoring.
+```
+
+### Configuration Examples
+
+#### Custom Maximum
+
+```neon
+parameters:
+    meliorstan:
+        excessive_method_length:
+            maximum: 30
+```
+
+```php
+<?php
+
+class Service
+{
+    public function handle(): void
+    {
+        // ... 35 lines ...
+    }
+    // ✗ Error: Method "handle" has 35 lines, which exceeds the maximum of 30.
+}
+```
+
+#### Ignore Whitespace and Comments
+
+```neon
+parameters:
+    meliorstan:
+        excessive_method_length:
+            ignore_whitespace: true
+```
+
+```php
+<?php
+
+class Calculator
+{
+    public function compute(): int
+    {
+        // Step 1: gather inputs
+        $a = $this->input();
+
+        // Step 2: validate
+        $b = $a * 2;
+
+        // ... lots of comments and blank lines, but only ~80 effective lines ...
+
+        return $b;
+    }
+    // ✓ Now valid - blanks and comment-only lines no longer count toward the threshold
+}
+```
+
+#### Ignore Pattern (Laravel-friendly)
+
+```neon
+parameters:
+    meliorstan:
+        excessive_method_length:
+            ignore_pattern: '^(boot|register|up|down|run|rules|handle)$'
+```
+
+```php
+<?php
+
+class CreateUsersTable extends Migration
+{
+    public function up(): void
+    {
+        // ... 150 lines of schema definition ...
+    }
+    // ✓ Now valid - "up" matches the ignore pattern
+
+    public function migrateData(): void
+    {
+        // ... 120 lines ...
+    }
+    // ✗ Error: Method "migrateData" has 120 lines, which exceeds the maximum of 100.
+}
+```
+
+## Important Notes
+
+- The rule applies to class methods, standalone functions, and closures (`function () { ... }`). Arrow functions (`fn () => ...`) are excluded by design because they are syntactically a single expression.
+- Methods without a body (abstract method declarations and interface method signatures) are skipped — the rule is concerned with implementation length, not signatures.
+- The `ignore_pattern` is case-insensitive and pattern delimiters (`/`) are added automatically — only provide the pattern itself.
+- Line counting uses `getStartLine()` and `getEndLine()` on the parser node, so the count includes the signature line, the opening brace, the body, and the closing brace.
+- When `ignore_whitespace` is `true`, the rule reads the source file once per candidate node to classify each line. This is a small per-method cost and only applies when the option is enabled.

--- a/docs/ExcessiveMethodLength.md
+++ b/docs/ExcessiveMethodLength.md
@@ -94,7 +94,7 @@ class Service
     {
         // ... 35 lines ...
     }
-    // ✗ Error: Method "handle" has 35 lines, which exceeds the maximum of 30.
+    // ✗ Error: Method "handle" has 35 lines, which exceeds the maximum of 30. Consider refactoring.
 }
 ```
 
@@ -152,7 +152,7 @@ class CreateUsersTable extends Migration
     {
         // ... 120 lines ...
     }
-    // ✗ Error: Method "migrateData" has 120 lines, which exceeds the maximum of 100.
+    // ✗ Error: Method "migrateData" has 120 lines, which exceeds the maximum of 100. Consider refactoring.
 }
 ```
 

--- a/src/Rules/ExcessiveMethodLength/Config.php
+++ b/src/Rules/ExcessiveMethodLength/Config.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ExcessiveMethodLength;
+
+class Config
+{
+    public function __construct(
+        protected int $maximum = 100,
+        protected bool $ignoreWhitespace = false,
+        protected string $ignorePattern = '',
+    ) {}
+
+    public function getMaximum(): int
+    {
+        return $this->maximum;
+    }
+
+    public function getIgnoreWhitespace(): bool
+    {
+        return $this->ignoreWhitespace;
+    }
+
+    public function getIgnorePattern(): string
+    {
+        return $this->ignorePattern;
+    }
+}

--- a/src/Rules/ExcessiveMethodLength/ExcessiveMethodLengthRule.php
+++ b/src/Rules/ExcessiveMethodLength/ExcessiveMethodLengthRule.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ExcessiveMethodLength;
+
+use InvalidArgumentException;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FunctionLike>
+ */
+class ExcessiveMethodLengthRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE_METHOD = 'Method "%s" has %d lines, which exceeds the maximum of %d. Consider refactoring.';
+
+    public const string ERROR_MESSAGE_TEMPLATE_FUNCTION = 'Function "%s" has %d lines, which exceeds the maximum of %d. Consider refactoring.';
+
+    public const string ERROR_MESSAGE_TEMPLATE_CLOSURE = 'Closure has %d lines, which exceeds the maximum of %d. Consider refactoring.';
+
+    public function __construct(
+        protected Config $config,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return FunctionLike::class;
+    }
+
+    /**
+     * @param FunctionLike $node
+     *
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->getStmts() === null) {
+            return [];
+        }
+
+        $name = $this->getName($node);
+
+        if ($name !== null && $this->shouldIgnoreByPattern($name)) {
+            return [];
+        }
+
+        $lineCount = $this->countLines($node, $scope->getFile());
+
+        if ($lineCount <= $this->config->getMaximum()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message($this->buildErrorMessage($node, $name, $lineCount))
+                ->identifier('MeliorStan.excessiveMethodLength')
+                ->build(),
+        ];
+    }
+
+    protected function getName(FunctionLike $node): ?string
+    {
+        if ($node instanceof ClassMethod || $node instanceof Function_) {
+            return $node->name->toString();
+        }
+
+        return null;
+    }
+
+    protected function shouldIgnoreByPattern(string $name): bool
+    {
+        $pattern = $this->config->getIgnorePattern();
+
+        if ($pattern === '') {
+            return false;
+        }
+
+        $regex = '/' . $pattern . '/i';
+
+        $result = @preg_match($regex, $name);
+
+        if ($result === false || preg_last_error() !== PREG_NO_ERROR) {
+            $error = preg_last_error_msg();
+
+            throw new InvalidArgumentException(
+                sprintf('Invalid regex pattern in ignore_pattern configuration: "%s". Error: %s', $pattern, $error)
+            );
+        }
+
+        return $result === 1;
+    }
+
+    protected function countLines(FunctionLike $node, string $filePath): int
+    {
+        $start = $node->getStartLine();
+        $end = $node->getEndLine();
+        $totalLines = $end - $start + 1;
+
+        if (! $this->config->getIgnoreWhitespace()) {
+            return $totalLines;
+        }
+
+        $contents = @file_get_contents($filePath);
+
+        if ($contents === false) {
+            return $totalLines;
+        }
+
+        $lines = explode("\n", $contents);
+
+        $count = 0;
+
+        for ($i = $start - 1; $i <= $end - 1; ++$i) {
+            if (! isset($lines[$i])) {
+                continue;
+            }
+
+            if ($this->isCountableLine($lines[$i])) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    protected function isCountableLine(string $line): bool
+    {
+        $trimmed = trim($line);
+
+        if ($trimmed === '') {
+            return false;
+        }
+
+        if (str_starts_with($trimmed, '//') || str_starts_with($trimmed, '#')) {
+            return false;
+        }
+
+        if (str_starts_with($trimmed, '/*') || str_starts_with($trimmed, '*/') || str_starts_with($trimmed, '*')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function buildErrorMessage(FunctionLike $node, ?string $name, int $lineCount): string
+    {
+        $maximum = $this->config->getMaximum();
+
+        if ($node instanceof ClassMethod) {
+            return sprintf(self::ERROR_MESSAGE_TEMPLATE_METHOD, $name, $lineCount, $maximum);
+        }
+
+        if ($node instanceof Function_) {
+            return sprintf(self::ERROR_MESSAGE_TEMPLATE_FUNCTION, $name, $lineCount, $maximum);
+        }
+
+        if ($node instanceof Closure) {
+            return sprintf(self::ERROR_MESSAGE_TEMPLATE_CLOSURE, $lineCount, $maximum);
+        }
+
+        return sprintf(self::ERROR_MESSAGE_TEMPLATE_CLOSURE, $lineCount, $maximum);
+    }
+}

--- a/src/Rules/ExcessiveMethodLength/ExcessiveMethodLengthRule.php
+++ b/src/Rules/ExcessiveMethodLength/ExcessiveMethodLengthRule.php
@@ -4,7 +4,6 @@ namespace Orrison\MeliorStan\Rules\ExcessiveMethodLength;
 
 use InvalidArgumentException;
 use PhpParser\Node;
-use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
@@ -18,11 +17,7 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 class ExcessiveMethodLengthRule implements Rule
 {
-    public const string ERROR_MESSAGE_TEMPLATE_METHOD = 'Method "%s" has %d lines, which exceeds the maximum of %d. Consider refactoring.';
-
-    public const string ERROR_MESSAGE_TEMPLATE_FUNCTION = 'Function "%s" has %d lines, which exceeds the maximum of %d. Consider refactoring.';
-
-    public const string ERROR_MESSAGE_TEMPLATE_CLOSURE = 'Closure has %d lines, which exceeds the maximum of %d. Consider refactoring.';
+    public const string ERROR_MESSAGE_TEMPLATE = '%s has %d lines, which exceeds the maximum of %d. Consider refactoring.';
 
     public function __construct(
         protected Config $config,
@@ -57,7 +52,9 @@ class ExcessiveMethodLengthRule implements Rule
         }
 
         return [
-            RuleErrorBuilder::message($this->buildErrorMessage($node, $name, $lineCount))
+            RuleErrorBuilder::message(
+                sprintf(self::ERROR_MESSAGE_TEMPLATE, $this->describeNode($node, $name), $lineCount, $this->config->getMaximum())
+            )
                 ->identifier('MeliorStan.excessiveMethodLength')
                 ->build(),
         ];
@@ -147,22 +144,16 @@ class ExcessiveMethodLengthRule implements Rule
         return true;
     }
 
-    protected function buildErrorMessage(FunctionLike $node, ?string $name, int $lineCount): string
+    protected function describeNode(FunctionLike $node, ?string $name): string
     {
-        $maximum = $this->config->getMaximum();
-
         if ($node instanceof ClassMethod) {
-            return sprintf(self::ERROR_MESSAGE_TEMPLATE_METHOD, $name, $lineCount, $maximum);
+            return sprintf('Method "%s"', $name);
         }
 
         if ($node instanceof Function_) {
-            return sprintf(self::ERROR_MESSAGE_TEMPLATE_FUNCTION, $name, $lineCount, $maximum);
+            return sprintf('Function "%s"', $name);
         }
 
-        if ($node instanceof Closure) {
-            return sprintf(self::ERROR_MESSAGE_TEMPLATE_CLOSURE, $lineCount, $maximum);
-        }
-
-        return sprintf(self::ERROR_MESSAGE_TEMPLATE_CLOSURE, $lineCount, $maximum);
+        return 'Closure';
     }
 }

--- a/src/Rules/ExcessiveMethodLength/ExcessiveMethodLengthRule.php
+++ b/src/Rules/ExcessiveMethodLength/ExcessiveMethodLengthRule.php
@@ -19,6 +19,11 @@ class ExcessiveMethodLengthRule implements Rule
 {
     public const string ERROR_MESSAGE_TEMPLATE = '%s has %d lines, which exceeds the maximum of %d. Consider refactoring.';
 
+    /**
+     * @var array<string, list<string>>
+     */
+    protected array $linesByFile = [];
+
     public function __construct(
         protected Config $config,
     ) {}
@@ -102,13 +107,11 @@ class ExcessiveMethodLengthRule implements Rule
             return $totalLines;
         }
 
-        $contents = @file_get_contents($filePath);
+        $lines = $this->getFileLines($filePath);
 
-        if ($contents === false) {
+        if ($lines === null) {
             return $totalLines;
         }
-
-        $lines = explode("\n", $contents);
 
         $count = 0;
 
@@ -123,6 +126,24 @@ class ExcessiveMethodLengthRule implements Rule
         }
 
         return $count;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    protected function getFileLines(string $filePath): ?array
+    {
+        if (array_key_exists($filePath, $this->linesByFile)) {
+            return $this->linesByFile[$filePath];
+        }
+
+        $contents = @file_get_contents($filePath);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        return $this->linesByFile[$filePath] = explode("\n", $contents);
     }
 
     protected function isCountableLine(string $line): bool

--- a/tests/Rules/ExcessiveMethodLength/DefaultOptionsTest.php
+++ b/tests/Rules/ExcessiveMethodLength/DefaultOptionsTest.php
@@ -20,7 +20,7 @@ class DefaultOptionsTest extends RuleTestCase
             ],
             [
                 [
-                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'longMethod', 13, 10),
+                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE, 'Method "longMethod"', 13, 10),
                     13,
                 ],
             ]
@@ -35,7 +35,7 @@ class DefaultOptionsTest extends RuleTestCase
             ],
             [
                 [
-                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE_FUNCTION, 'emlLongFunction', 13, 10),
+                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE, 'Function "emlLongFunction"', 13, 10),
                     11,
                 ],
             ]
@@ -50,7 +50,7 @@ class DefaultOptionsTest extends RuleTestCase
             ],
             [
                 [
-                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE_CLOSURE, 12, 10),
+                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE, 'Closure', 12, 10),
                     10,
                 ],
             ]

--- a/tests/Rules/ExcessiveMethodLength/DefaultOptionsTest.php
+++ b/tests/Rules/ExcessiveMethodLength/DefaultOptionsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength;
+
+use Orrison\MeliorStan\Rules\ExcessiveMethodLength\ExcessiveMethodLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessiveMethodLengthRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testLongMethodTriggers(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/LongMethodClass.php',
+                __DIR__ . '/Fixture/ShortMethodClass.php',
+            ],
+            [
+                [
+                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'longMethod', 13, 10),
+                    13,
+                ],
+            ]
+        );
+    }
+
+    public function testStandaloneFunctions(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/StandaloneFunctions.php',
+            ],
+            [
+                [
+                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE_FUNCTION, 'emlLongFunction', 13, 10),
+                    11,
+                ],
+            ]
+        );
+    }
+
+    public function testTopLevelClosures(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/TopLevelClosures.php',
+            ],
+            [
+                [
+                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE_CLOSURE, 12, 10),
+                    10,
+                ],
+            ]
+        );
+    }
+
+    public function testAbstractAndInterfaceMethodsAreSkipped(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/AbstractMethodClass.php',
+                __DIR__ . '/Fixture/InterfaceMethods.php',
+            ],
+            []
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/default.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessiveMethodLengthRule::class);
+    }
+}

--- a/tests/Rules/ExcessiveMethodLength/Fixture/AbstractMethodClass.php
+++ b/tests/Rules/ExcessiveMethodLength/Fixture/AbstractMethodClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength\Fixture;
+
+abstract class AbstractMethodClass
+{
+    abstract public function abstractMethod(): void;
+
+    abstract public function anotherAbstractMethod(string $value): int;
+}

--- a/tests/Rules/ExcessiveMethodLength/Fixture/InterfaceMethods.php
+++ b/tests/Rules/ExcessiveMethodLength/Fixture/InterfaceMethods.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength\Fixture;
+
+interface InterfaceMethods
+{
+    public function methodOne(): void;
+
+    public function methodTwo(string $value): int;
+}

--- a/tests/Rules/ExcessiveMethodLength/Fixture/LaravelStyleClass.php
+++ b/tests/Rules/ExcessiveMethodLength/Fixture/LaravelStyleClass.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength\Fixture;
+
+class LaravelStyleClass
+{
+    public function boot(): void
+    {
+        $x1 = 1;
+        $x2 = 2;
+        $x3 = 3;
+        $x4 = 4;
+        $x5 = 5;
+        $x6 = 6;
+        $x7 = 7;
+        $x8 = 8;
+        $x9 = 9;
+        $x10 = 10;
+    }
+
+    public function up(): void
+    {
+        $x1 = 1;
+        $x2 = 2;
+        $x3 = 3;
+        $x4 = 4;
+        $x5 = 5;
+        $x6 = 6;
+        $x7 = 7;
+        $x8 = 8;
+        $x9 = 9;
+        $x10 = 10;
+    }
+
+    public function notIgnoredMethod(): void
+    {
+        $x1 = 1;
+        $x2 = 2;
+        $x3 = 3;
+        $x4 = 4;
+        $x5 = 5;
+        $x6 = 6;
+        $x7 = 7;
+        $x8 = 8;
+        $x9 = 9;
+        $x10 = 10;
+    }
+}

--- a/tests/Rules/ExcessiveMethodLength/Fixture/LongMethodClass.php
+++ b/tests/Rules/ExcessiveMethodLength/Fixture/LongMethodClass.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength\Fixture;
+
+class LongMethodClass
+{
+    public function shortMethod(): void
+    {
+        $a = 1;
+        $b = 2;
+    }
+
+    public function longMethod(): void
+    {
+        $x1 = 1;
+        $x2 = 2;
+        $x3 = 3;
+        $x4 = 4;
+        $x5 = 5;
+        $x6 = 6;
+        $x7 = 7;
+        $x8 = 8;
+        $x9 = 9;
+        $x10 = 10;
+    }
+}

--- a/tests/Rules/ExcessiveMethodLength/Fixture/PaddedMethodClass.php
+++ b/tests/Rules/ExcessiveMethodLength/Fixture/PaddedMethodClass.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength\Fixture;
+
+class PaddedMethodClass
+{
+    public function paddedMethod(): void
+    {
+        // Initialize state
+        $a = 1;
+
+        $b = 2;
+
+        $c = 3;
+
+        $d = 4;
+
+        $e = 5;
+
+        $f = 6;
+
+        $g = 7;
+    }
+
+    public function genuinelyLongMethod(): void
+    {
+        $x1 = 1;
+        $x2 = 2;
+        $x3 = 3;
+        $x4 = 4;
+        $x5 = 5;
+        $x6 = 6;
+        $x7 = 7;
+        $x8 = 8;
+        $x9 = 9;
+        $x10 = 10;
+    }
+}

--- a/tests/Rules/ExcessiveMethodLength/Fixture/ShortMethodClass.php
+++ b/tests/Rules/ExcessiveMethodLength/Fixture/ShortMethodClass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength\Fixture;
+
+class ShortMethodClass
+{
+    public function methodOne(): int
+    {
+        return 1;
+    }
+
+    public function methodTwo(): int
+    {
+        return 2;
+    }
+}

--- a/tests/Rules/ExcessiveMethodLength/Fixture/StandaloneFunctions.php
+++ b/tests/Rules/ExcessiveMethodLength/Fixture/StandaloneFunctions.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength\Fixture;
+
+function emlShortFunction(): void
+{
+    $a = 1;
+    $b = 2;
+}
+
+function emlLongFunction(): void
+{
+    $x1 = 1;
+    $x2 = 2;
+    $x3 = 3;
+    $x4 = 4;
+    $x5 = 5;
+    $x6 = 6;
+    $x7 = 7;
+    $x8 = 8;
+    $x9 = 9;
+    $x10 = 10;
+}

--- a/tests/Rules/ExcessiveMethodLength/Fixture/TopLevelClosures.php
+++ b/tests/Rules/ExcessiveMethodLength/Fixture/TopLevelClosures.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength\Fixture;
+
+$emlShortClosure = function (): void {
+    $a = 1;
+    $b = 2;
+};
+
+$emlLongClosure = function (): void {
+    $x1 = 1;
+    $x2 = 2;
+    $x3 = 3;
+    $x4 = 4;
+    $x5 = 5;
+    $x6 = 6;
+    $x7 = 7;
+    $x8 = 8;
+    $x9 = 9;
+    $x10 = 10;
+};

--- a/tests/Rules/ExcessiveMethodLength/IgnorePatternTest.php
+++ b/tests/Rules/ExcessiveMethodLength/IgnorePatternTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength;
+
+use Orrison\MeliorStan\Rules\ExcessiveMethodLength\ExcessiveMethodLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessiveMethodLengthRule>
+ */
+class IgnorePatternTest extends RuleTestCase
+{
+    public function testIgnoredMethodNamesAreSkipped(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/LaravelStyleClass.php',
+            ],
+            [
+                [
+                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'notIgnoredMethod', 13, 10),
+                    35,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignore-pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessiveMethodLengthRule::class);
+    }
+}

--- a/tests/Rules/ExcessiveMethodLength/IgnorePatternTest.php
+++ b/tests/Rules/ExcessiveMethodLength/IgnorePatternTest.php
@@ -19,7 +19,7 @@ class IgnorePatternTest extends RuleTestCase
             ],
             [
                 [
-                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'notIgnoredMethod', 13, 10),
+                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE, 'Method "notIgnoredMethod"', 13, 10),
                     35,
                 ],
             ]

--- a/tests/Rules/ExcessiveMethodLength/IgnoreWhitespaceTest.php
+++ b/tests/Rules/ExcessiveMethodLength/IgnoreWhitespaceTest.php
@@ -19,7 +19,7 @@ class IgnoreWhitespaceTest extends RuleTestCase
             ],
             [
                 [
-                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'genuinelyLongMethod', 13, 10),
+                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE, 'Method "genuinelyLongMethod"', 13, 10),
                     25,
                 ],
             ]

--- a/tests/Rules/ExcessiveMethodLength/IgnoreWhitespaceTest.php
+++ b/tests/Rules/ExcessiveMethodLength/IgnoreWhitespaceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength;
+
+use Orrison\MeliorStan\Rules\ExcessiveMethodLength\ExcessiveMethodLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessiveMethodLengthRule>
+ */
+class IgnoreWhitespaceTest extends RuleTestCase
+{
+    public function testWhitespaceAndCommentsAreIgnored(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/PaddedMethodClass.php',
+            ],
+            [
+                [
+                    sprintf(ExcessiveMethodLengthRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'genuinelyLongMethod', 13, 10),
+                    25,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignore-whitespace.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessiveMethodLengthRule::class);
+    }
+}

--- a/tests/Rules/ExcessiveMethodLength/InvalidPatternTest.php
+++ b/tests/Rules/ExcessiveMethodLength/InvalidPatternTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveMethodLength;
+
+use InvalidArgumentException;
+use Orrison\MeliorStan\Rules\ExcessiveMethodLength\ExcessiveMethodLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessiveMethodLengthRule>
+ */
+class InvalidPatternTest extends RuleTestCase
+{
+    public function testInvalidPattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid regex pattern in ignore_pattern configuration');
+
+        $this->analyse([
+            __DIR__ . '/Fixture/LongMethodClass.php',
+        ], []);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/invalid-pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessiveMethodLengthRule::class);
+    }
+}

--- a/tests/Rules/ExcessiveMethodLength/config/default.neon
+++ b/tests/Rules/ExcessiveMethodLength/config/default.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveMethodLength\ExcessiveMethodLengthRule
+
+parameters:
+    meliorstan:
+        excessive_method_length:
+            maximum: 10
+            ignore_whitespace: false
+            ignore_pattern: ''

--- a/tests/Rules/ExcessiveMethodLength/config/ignore-pattern.neon
+++ b/tests/Rules/ExcessiveMethodLength/config/ignore-pattern.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveMethodLength\ExcessiveMethodLengthRule
+
+parameters:
+    meliorstan:
+        excessive_method_length:
+            maximum: 10
+            ignore_whitespace: false
+            ignore_pattern: '^(boot|register|up|down|handle)$'

--- a/tests/Rules/ExcessiveMethodLength/config/ignore-whitespace.neon
+++ b/tests/Rules/ExcessiveMethodLength/config/ignore-whitespace.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveMethodLength\ExcessiveMethodLengthRule
+
+parameters:
+    meliorstan:
+        excessive_method_length:
+            maximum: 10
+            ignore_whitespace: true
+            ignore_pattern: ''

--- a/tests/Rules/ExcessiveMethodLength/config/invalid-pattern.neon
+++ b/tests/Rules/ExcessiveMethodLength/config/invalid-pattern.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveMethodLength\ExcessiveMethodLengthRule
+
+parameters:
+    meliorstan:
+        excessive_method_length:
+            maximum: 10
+            ignore_whitespace: false
+            ignore_pattern: '/invalid[regex'


### PR DESCRIPTION
This pull request introduces a new rule, `ExcessiveMethodLength`, to the codebase. This rule detects methods, functions, and closures that exceed a configurable line count threshold, helping to enforce better code organization and maintainability. The rule is fully configurable, supports ignoring whitespace and comments, and allows for excluding specific method names via a pattern. The implementation includes documentation, configuration, the rule itself, and a comprehensive test suite.

The most important changes are:

**Rule Implementation and Documentation**
* Added the `ExcessiveMethodLength` rule with configuration options for maximum lines, ignoring whitespace/comments, and ignoring methods by name pattern. (`src/Rules/ExcessiveMethodLength/ExcessiveMethodLengthRule.php` [[1]](diffhunk://#diff-4c8a858623d7e39be891c27afd7d0c1bdd2fe0f212b158c56178a7154d0ff988R1-R168) `src/Rules/ExcessiveMethodLength/Config.php` [[2]](diffhunk://#diff-76f58a4e8761fe8237d6fbb0c2f3e4acaca5957ac6330051f24cbd67787cfed4R1-R27)
* Created detailed documentation for the rule, including configuration, usage, and examples. (`docs/ExcessiveMethodLength.md` [docs/ExcessiveMethodLength.mdR1-R165](diffhunk://#diff-670f577ba1f254b594da1f5543a046b150e8f1a957de005847af8b7c014d9996R1-R165))
* Registered the rule in the documentation summary. (`README.md` [README.mdR126](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126))

**Configuration**
* Added configuration schema and default parameters for the rule in the extension configuration. (`config/extension.neon` [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R122-R126) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R225-R228) [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R380-R385)

**Testing**
* Added an extensive test suite covering default behavior, ignoring whitespace, ignoring methods by pattern, and skipping abstract/interface methods. (`tests/Rules/ExcessiveMethodLength/DefaultOptionsTest.php` [[1]](diffhunk://#diff-65c6a9a6e02b3fa0b30b41f676ce3049431cce4a9454f0dc4d3fa7d471f348d8R1-R80) `tests/Rules/ExcessiveMethodLength/IgnoreWhitespaceTest.php` [[2]](diffhunk://#diff-ca9d07ff8243cd54c4f36e5ba848e2c2e5ad8bb3d56c27b7179c2d41b78d98e1R1-R38) `tests/Rules/ExcessiveMethodLength/IgnorePatternTest.php` [[3]](diffhunk://#diff-1c9ce88867d03d46f51f2ac0bbc49e81f0b6276f046985cee4c879135a7d6fb6R1-R38) plus test fixtures [[4]](diffhunk://#diff-0eec1e4822f5845ece4114e779aa3fe26c06e36842570d3a2f6fd57879a4780aR1-R10) [[5]](diffhunk://#diff-5e3b97f6d718412752977890dba3d174a4c1c9682d794411c26fb941edf57facR1-R10) [[6]](diffhunk://#diff-cd0a0e0a9f5e0aaf9ea64a2eb6f3c3d1bcd107c693baf822d6ff75181ac14f3bR1-R48) [[7]](diffhunk://#diff-c3bcea18cb86d68704dfc6d94c88ab790158a9988afcfcd09d6387423b69967cR1-R26) [[8]](diffhunk://#diff-22d149e6b30213cb27f52cef39c658b3f5fa02d46716e7a440bd5e5f9306a7a2R1-R38) [[9]](diffhunk://#diff-4829f712aa5e4ff527769a5feac3cedda625c283f8162d80720e9deba53b9462R1-R16) [[10]](diffhunk://#diff-2cf8feaae95875f3570aef1a7439a91199e20762051389061096176c02bc85e6R1-R23) [[11]](diffhunk://#diff-d50fad83edf74e2853fb99391e4076f86c89d193d48a300ebda31d278a4fb683R1-R21)

This addition will help teams identify and refactor overly long methods, keeping codebases more maintainable and readable.

Closes https://github.com/Orrison/MeliorStan/issues/39