### PR TITLE
Add ExcessiveClassLength rule with configuration, documentation, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ parameters:
 | **[ForbidGotoStatements](docs/ForbidGotoStatements.md)** | Detects and reports usage of goto statements | Goto Statements |
 | **[CouplingBetweenObjects](docs/CouplingBetweenObjects.md)** | Detects classes with too many type dependencies | Classes, Interfaces, Traits, Enums |
 | **[DepthOfInheritance](docs/DepthOfInheritance.md)** | Detects classes with excessively deep inheritance chains | Classes |
+| **[ExcessiveClassLength](docs/ExcessiveClassLength.md)** | Detects classes, interfaces, traits, and enums with excessive line counts | Classes, Interfaces, Traits, Enums |
 | **[ExcessiveMethodLength](docs/ExcessiveMethodLength.md)** | Detects methods, functions, and closures with excessive line counts | Methods, Functions, Closures |
 | **[ExcessivePublicCount](docs/ExcessivePublicCount.md)** | Detects classes with an excessive public API surface (public methods + properties) | Classes, Interfaces, Traits, Enums |
 | **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -124,6 +124,11 @@ parametersSchema:
             ignore_whitespace: bool(),
             ignore_pattern: string(),
         ]),
+        excessive_class_length: structure([
+            maximum: int(),
+            ignore_whitespace: bool(),
+            ignore_pattern: string(),
+        ]),
     ])
 
 # default parameters
@@ -224,6 +229,10 @@ parameters:
             ignore_static_properties: true
         excessive_method_length:
             maximum: 100
+            ignore_whitespace: false
+            ignore_pattern: ''
+        excessive_class_length:
+            maximum: 1000
             ignore_whitespace: false
             ignore_pattern: ''
 
@@ -383,3 +392,9 @@ services:
             - %meliorstan.excessive_method_length.maximum%
             - %meliorstan.excessive_method_length.ignore_whitespace%
             - %meliorstan.excessive_method_length.ignore_pattern%
+    -
+        factory: Orrison\MeliorStan\Rules\ExcessiveClassLength\Config
+        arguments:
+            - %meliorstan.excessive_class_length.maximum%
+            - %meliorstan.excessive_class_length.ignore_whitespace%
+            - %meliorstan.excessive_class_length.ignore_pattern%

--- a/docs/ExcessiveClassLength.md
+++ b/docs/ExcessiveClassLength.md
@@ -1,0 +1,144 @@
+# ExcessiveClassLength
+
+This rule detects classes, interfaces, traits, and enums whose line count exceeds a configurable threshold. Excessively long class-like types are a common sign of the "God class" anti-pattern — a single type that does too much and should be split into smaller, focused units.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `maximum`
+- **Type**: `int`
+- **Default**: `1000`
+- **Description**: The maximum number of lines a class, interface, trait, or enum may have before the rule reports an error. Lines are counted from the first line of the declaration through the closing brace, inclusive.
+
+### `ignore_whitespace`
+- **Type**: `bool`
+- **Default**: `false`
+- **Description**: When `true`, blank lines and comment-only lines (single-line `//`, `#`, and docblock/`/* */` lines) are excluded from the line count. Useful for codebases that prefer the "effective lines of code" metric over raw line totals.
+
+### `ignore_pattern`
+- **Type**: `string`
+- **Default**: `''`
+- **Description**: A regular expression pattern (without delimiters) matched against the class, interface, trait, or enum name. When a name matches, the declaration is skipped. Useful for legitimately large types that cannot easily be split, such as generated code or legacy God classes being incrementally refactored. Set to an empty string to apply the rule to all names. Anonymous classes have no name and are never flagged by this rule.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveClassLength\ExcessiveClassLengthRule
+
+parameters:
+    meliorstan:
+        excessive_class_length:
+            maximum: 1000
+            ignore_whitespace: false
+            ignore_pattern: ''
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class OrderService
+{
+    // ... 1100 lines of methods, properties, constants, and nested logic ...
+}
+// ✗ Error: Class "OrderService" has 1100 lines, which exceeds the maximum of 1000. Consider refactoring.
+
+interface LargeContract
+{
+    // ... 1050 lines of method signatures ...
+}
+// ✗ Error: Interface "LargeContract" has 1050 lines, which exceeds the maximum of 1000. Consider refactoring.
+
+class SmallService
+{
+    // ... 200 lines ...
+}
+// ✓ Valid - within the 1000-line limit
+```
+
+### Configuration Examples
+
+#### Custom Maximum
+
+```neon
+parameters:
+    meliorstan:
+        excessive_class_length:
+            maximum: 300
+```
+
+```php
+<?php
+
+class UserRepository
+{
+    // ... 350 lines ...
+}
+// ✗ Error: Class "UserRepository" has 350 lines, which exceeds the maximum of 300. Consider refactoring.
+```
+
+#### Ignore Whitespace and Comments
+
+```neon
+parameters:
+    meliorstan:
+        excessive_class_length:
+            ignore_whitespace: true
+```
+
+```php
+<?php
+
+class WellDocumentedService
+{
+    /**
+     * Lots of PHPDoc blocks and blank lines between methods,
+     * but only ~800 lines of actual code.
+     */
+
+    // ... many blank lines and comments, but fewer effective lines ...
+}
+// ✓ Now valid - blanks and comment-only lines no longer count toward the threshold
+```
+
+#### Ignore Pattern (Laravel-friendly)
+
+```neon
+parameters:
+    meliorstan:
+        excessive_class_length:
+            ignore_pattern: '^(Legacy|Generated|.*Migration)$'
+```
+
+```php
+<?php
+
+class LegacyOrderProcessor
+{
+    // ... 2000 lines of legacy code being incrementally refactored ...
+}
+// ✓ Now valid - "LegacyOrderProcessor" matches the ignore pattern
+
+class OrderService
+{
+    // ... 1100 lines ...
+}
+// ✗ Error: Class "OrderService" has 1100 lines, which exceeds the maximum of 1000. Consider refactoring.
+```
+
+## Important Notes
+
+- The rule applies to named classes, interfaces, traits, and enums. Anonymous classes (`new class { ... }`) are always skipped.
+- Line counting uses `getStartLine()` and `getEndLine()` on the parser node, so the count includes the declaration line, the opening brace, the body, and the closing brace.
+- When `ignore_whitespace` is `true`, the rule reads the source file to classify each line. This is a small per-class cost and only applies when the option is enabled.
+- The `ignore_pattern` is case-insensitive and pattern delimiters (`/`) are added automatically — only provide the pattern itself.

--- a/src/Rules/ExcessiveClassLength/Config.php
+++ b/src/Rules/ExcessiveClassLength/Config.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ExcessiveClassLength;
+
+class Config
+{
+    public function __construct(
+        protected int $maximum = 1000,
+        protected bool $ignoreWhitespace = false,
+        protected string $ignorePattern = '',
+    ) {}
+
+    public function getMaximum(): int
+    {
+        return $this->maximum;
+    }
+
+    public function getIgnoreWhitespace(): bool
+    {
+        return $this->ignoreWhitespace;
+    }
+
+    public function getIgnorePattern(): string
+    {
+        return $this->ignorePattern;
+    }
+}

--- a/src/Rules/ExcessiveClassLength/ExcessiveClassLengthRule.php
+++ b/src/Rules/ExcessiveClassLength/ExcessiveClassLengthRule.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ExcessiveClassLength;
+
+use InvalidArgumentException;
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Trait_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassLike>
+ */
+class ExcessiveClassLengthRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = '%s has %d lines, which exceeds the maximum of %d. Consider refactoring.';
+
+    /**
+     * @var array<string, list<string>>
+     */
+    protected array $linesByFile = [];
+
+    public function __construct(
+        protected Config $config,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return ClassLike::class;
+    }
+
+    /**
+     * @param ClassLike $node
+     *
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node instanceof Class_ && $node->isAnonymous()) {
+            return [];
+        }
+
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        $name = $node->name->toString();
+
+        if ($this->shouldIgnoreByPattern($name)) {
+            return [];
+        }
+
+        $lineCount = $this->countLines($node, $scope->getFile());
+
+        if ($lineCount <= $this->config->getMaximum()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(self::ERROR_MESSAGE_TEMPLATE, $this->describeNode($node), $lineCount, $this->config->getMaximum())
+            )
+                ->identifier('MeliorStan.excessiveClassLength')
+                ->build(),
+        ];
+    }
+
+    protected function shouldIgnoreByPattern(string $name): bool
+    {
+        $pattern = $this->config->getIgnorePattern();
+
+        if ($pattern === '') {
+            return false;
+        }
+
+        $regex = '/' . $pattern . '/i';
+
+        $result = @preg_match($regex, $name);
+
+        if ($result === false || preg_last_error() !== PREG_NO_ERROR) {
+            $error = preg_last_error_msg();
+
+            throw new InvalidArgumentException(
+                sprintf('Invalid regex pattern in ignore_pattern configuration: "%s". Error: %s', $pattern, $error)
+            );
+        }
+
+        return $result === 1;
+    }
+
+    protected function countLines(ClassLike $node, string $filePath): int
+    {
+        $start = $node->getStartLine();
+        $end = $node->getEndLine();
+        $totalLines = $end - $start + 1;
+
+        if (! $this->config->getIgnoreWhitespace()) {
+            return $totalLines;
+        }
+
+        $lines = $this->getFileLines($filePath);
+
+        if ($lines === null) {
+            return $totalLines;
+        }
+
+        $count = 0;
+
+        for ($i = $start - 1; $i <= $end - 1; ++$i) {
+            if (! isset($lines[$i])) {
+                continue;
+            }
+
+            if ($this->isCountableLine($lines[$i])) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    protected function getFileLines(string $filePath): ?array
+    {
+        if (array_key_exists($filePath, $this->linesByFile)) {
+            return $this->linesByFile[$filePath];
+        }
+
+        $contents = @file_get_contents($filePath);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        return $this->linesByFile[$filePath] = explode("\n", $contents);
+    }
+
+    protected function isCountableLine(string $line): bool
+    {
+        $trimmed = trim($line);
+
+        if ($trimmed === '') {
+            return false;
+        }
+
+        if (str_starts_with($trimmed, '//') || str_starts_with($trimmed, '#')) {
+            return false;
+        }
+
+        if (str_starts_with($trimmed, '/*') || str_starts_with($trimmed, '*/') || str_starts_with($trimmed, '*')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function describeNode(ClassLike $node): string
+    {
+        $name = $node->name instanceof Identifier ? $node->name->toString() : '';
+
+        if ($node instanceof Interface_) {
+            return sprintf('Interface "%s"', $name);
+        }
+
+        if ($node instanceof Trait_) {
+            return sprintf('Trait "%s"', $name);
+        }
+
+        if ($node instanceof Enum_) {
+            return sprintf('Enum "%s"', $name);
+        }
+
+        return sprintf('Class "%s"', $name);
+    }
+}

--- a/tests/Rules/ExcessiveClassLength/DefaultOptionsTest.php
+++ b/tests/Rules/ExcessiveClassLength/DefaultOptionsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength;
+
+use Orrison\MeliorStan\Rules\ExcessiveClassLength\ExcessiveClassLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessiveClassLengthRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testLongClassTriggers(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/LongClass.php',
+                __DIR__ . '/Fixture/ShortClass.php',
+            ],
+            [
+                [
+                    sprintf(ExcessiveClassLengthRule::ERROR_MESSAGE_TEMPLATE, 'Class "LongClass"', 14, 5),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    public function testLongInterfaceTriggers(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/LongInterface.php',
+            ],
+            [
+                [
+                    sprintf(ExcessiveClassLengthRule::ERROR_MESSAGE_TEMPLATE, 'Interface "LongInterface"', 14, 5),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    public function testLongTraitTriggers(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/LongTrait.php',
+            ],
+            [
+                [
+                    sprintf(ExcessiveClassLengthRule::ERROR_MESSAGE_TEMPLATE, 'Trait "LongTrait"', 14, 5),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    public function testLongEnumTriggers(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/LongEnum.php',
+            ],
+            [
+                [
+                    sprintf(ExcessiveClassLengthRule::ERROR_MESSAGE_TEMPLATE, 'Enum "LongEnum"', 9, 5),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    public function testAnonymousClassIsSkipped(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/AnonymousClassHolder.php',
+            ],
+            []
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/default.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessiveClassLengthRule::class);
+    }
+}

--- a/tests/Rules/ExcessiveClassLength/Fixture/AnonymousClassHolder.php
+++ b/tests/Rules/ExcessiveClassLength/Fixture/AnonymousClassHolder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength\Fixture;
+
+$anonymousObj = new class () {
+    public string $propA = 'a';
+
+    public string $propB = 'b';
+
+    public string $propC = 'c';
+
+    public string $propD = 'd';
+
+    public string $propE = 'e';
+
+    public string $propF = 'f';
+};

--- a/tests/Rules/ExcessiveClassLength/Fixture/DenseLongClass.php
+++ b/tests/Rules/ExcessiveClassLength/Fixture/DenseLongClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength\Fixture;
+
+class DenseLongClass
+{
+    public string $propA = 'a';
+
+    public string $propB = 'b';
+
+    public string $propC = 'c';
+
+    public string $propD = 'd';
+
+    public string $propE = 'e';
+
+    public string $propF = 'f';
+}

--- a/tests/Rules/ExcessiveClassLength/Fixture/LongClass.php
+++ b/tests/Rules/ExcessiveClassLength/Fixture/LongClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength\Fixture;
+
+class LongClass
+{
+    public string $propA = 'a';
+
+    public string $propB = 'b';
+
+    public string $propC = 'c';
+
+    public string $propD = 'd';
+
+    public string $propE = 'e';
+
+    public string $propF = 'f';
+}

--- a/tests/Rules/ExcessiveClassLength/Fixture/LongEnum.php
+++ b/tests/Rules/ExcessiveClassLength/Fixture/LongEnum.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength\Fixture;
+
+enum LongEnum
+{
+    case CaseA;
+    case CaseB;
+    case CaseC;
+    case CaseD;
+    case CaseE;
+    case CaseF;
+}

--- a/tests/Rules/ExcessiveClassLength/Fixture/LongInterface.php
+++ b/tests/Rules/ExcessiveClassLength/Fixture/LongInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength\Fixture;
+
+interface LongInterface
+{
+    public function methodA(): void;
+
+    public function methodB(): void;
+
+    public function methodC(): void;
+
+    public function methodD(): void;
+
+    public function methodE(): void;
+
+    public function methodF(): void;
+}

--- a/tests/Rules/ExcessiveClassLength/Fixture/LongTrait.php
+++ b/tests/Rules/ExcessiveClassLength/Fixture/LongTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength\Fixture;
+
+trait LongTrait
+{
+    public string $propA = 'a';
+
+    public string $propB = 'b';
+
+    public string $propC = 'c';
+
+    public string $propD = 'd';
+
+    public string $propE = 'e';
+
+    public string $propF = 'f';
+}

--- a/tests/Rules/ExcessiveClassLength/Fixture/PatternMatchedClass.php
+++ b/tests/Rules/ExcessiveClassLength/Fixture/PatternMatchedClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength\Fixture;
+
+class PatternMatchedClass
+{
+    public string $propA = 'a';
+
+    public string $propB = 'b';
+
+    public string $propC = 'c';
+
+    public string $propD = 'd';
+
+    public string $propE = 'e';
+
+    public string $propF = 'f';
+}

--- a/tests/Rules/ExcessiveClassLength/Fixture/ShortClass.php
+++ b/tests/Rules/ExcessiveClassLength/Fixture/ShortClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength\Fixture;
+
+class ShortClass
+{
+    public string $prop = 'a';
+}

--- a/tests/Rules/ExcessiveClassLength/Fixture/SparseLongClass.php
+++ b/tests/Rules/ExcessiveClassLength/Fixture/SparseLongClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength\Fixture;
+
+class SparseLongClass
+{
+    // This is a comment
+
+    // Another comment
+
+    // Yet another comment
+
+    public string $propA = 'a';
+
+    // More comments here
+
+    public string $propB = 'b';
+}

--- a/tests/Rules/ExcessiveClassLength/IgnorePatternTest.php
+++ b/tests/Rules/ExcessiveClassLength/IgnorePatternTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength;
+
+use Orrison\MeliorStan\Rules\ExcessiveClassLength\ExcessiveClassLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessiveClassLengthRule>
+ */
+class IgnorePatternTest extends RuleTestCase
+{
+    public function testIgnoredClassNamesAreSkipped(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/PatternMatchedClass.php',
+                __DIR__ . '/Fixture/LongClass.php',
+            ],
+            [
+                [
+                    sprintf(ExcessiveClassLengthRule::ERROR_MESSAGE_TEMPLATE, 'Class "LongClass"', 14, 5),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignore-pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessiveClassLengthRule::class);
+    }
+}

--- a/tests/Rules/ExcessiveClassLength/IgnoreWhitespaceTest.php
+++ b/tests/Rules/ExcessiveClassLength/IgnoreWhitespaceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength;
+
+use Orrison\MeliorStan\Rules\ExcessiveClassLength\ExcessiveClassLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessiveClassLengthRule>
+ */
+class IgnoreWhitespaceTest extends RuleTestCase
+{
+    public function testWhitespaceAndCommentsAreIgnored(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/SparseLongClass.php',
+                __DIR__ . '/Fixture/DenseLongClass.php',
+            ],
+            [
+                [
+                    sprintf(ExcessiveClassLengthRule::ERROR_MESSAGE_TEMPLATE, 'Class "DenseLongClass"', 9, 5),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignore-whitespace.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessiveClassLengthRule::class);
+    }
+}

--- a/tests/Rules/ExcessiveClassLength/InvalidPatternTest.php
+++ b/tests/Rules/ExcessiveClassLength/InvalidPatternTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveClassLength;
+
+use InvalidArgumentException;
+use Orrison\MeliorStan\Rules\ExcessiveClassLength\ExcessiveClassLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessiveClassLengthRule>
+ */
+class InvalidPatternTest extends RuleTestCase
+{
+    public function testInvalidPattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid regex pattern in ignore_pattern configuration');
+
+        $this->analyse([
+            __DIR__ . '/Fixture/LongClass.php',
+        ], []);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/invalid-pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessiveClassLengthRule::class);
+    }
+}

--- a/tests/Rules/ExcessiveClassLength/config/default.neon
+++ b/tests/Rules/ExcessiveClassLength/config/default.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveClassLength\ExcessiveClassLengthRule
+
+parameters:
+    meliorstan:
+        excessive_class_length:
+            maximum: 5
+            ignore_whitespace: false
+            ignore_pattern: ''

--- a/tests/Rules/ExcessiveClassLength/config/ignore-pattern.neon
+++ b/tests/Rules/ExcessiveClassLength/config/ignore-pattern.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveClassLength\ExcessiveClassLengthRule
+
+parameters:
+    meliorstan:
+        excessive_class_length:
+            maximum: 5
+            ignore_whitespace: false
+            ignore_pattern: '^PatternMatched'

--- a/tests/Rules/ExcessiveClassLength/config/ignore-whitespace.neon
+++ b/tests/Rules/ExcessiveClassLength/config/ignore-whitespace.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveClassLength\ExcessiveClassLengthRule
+
+parameters:
+    meliorstan:
+        excessive_class_length:
+            maximum: 5
+            ignore_whitespace: true
+            ignore_pattern: ''

--- a/tests/Rules/ExcessiveClassLength/config/invalid-pattern.neon
+++ b/tests/Rules/ExcessiveClassLength/config/invalid-pattern.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveClassLength\ExcessiveClassLengthRule
+
+parameters:
+    meliorstan:
+        excessive_class_length:
+            maximum: 5
+            ignore_whitespace: false
+            ignore_pattern: '/invalid[regex'


### PR DESCRIPTION
This pull request introduces a new rule, `ExcessiveClassLength`, to the codebase. This rule detects classes, interfaces, traits, and enums whose line count exceeds a configurable threshold, helping to identify "God classes" and encourage better code organization. The rule is fully documented, configurable, and covered by automated tests.

**New Rule: ExcessiveClassLength**

- Implementation:
  - Added `ExcessiveClassLengthRule` to detect class-like types exceeding a configurable line limit, with options to ignore whitespace/comments and to skip specific names via regex patterns. Anonymous classes are always excluded.
  - Added a configuration class `Config` for dependency injection and parameter management.

- Configuration and Documentation:
  - Updated `config/extension.neon` to support the new rule, including parameters for maximum lines, whitespace handling, and ignore patterns, with sensible defaults. [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R127-R131) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R234-R237) [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R395-R400)
  - Added documentation in `docs/ExcessiveClassLength.md` describing the rule, configuration options, usage examples, and important notes.
  - Updated `README.md` to list and describe the new rule.

- Automated Testing:
  - Added comprehensive tests for default behavior, whitespace/comment ignoring, and ignore patterns, with fixtures for various class-like types and edge cases. [[1]](diffhunk://#diff-3d95bde096ef4f9268651a45a20374e6aa6397ff2ce39f93644d5a62c16a796bR1-R94) [[2]](diffhunk://#diff-4487b4b3d3912da17f53893aa616403f33f06de758293887d0504c4fa6af9c9cR1-R39) [[3]](diffhunk://#diff-249fbd2e61384949ec83d08d867592e6cf58cd98bf065c5f17419db53e966f82R1-R39) [[4]](diffhunk://#diff-5d94efd35931a83f5be552707a7a7746a1353797e9f48408a2a047d935da0795R1-R18) [[5]](diffhunk://#diff-13ead0433ec01bedd96697f53a557ccf2515fadc9ca27e0614b325aed48d2be1R1-R18) [[6]](diffhunk://#diff-278b7ccc9556ceb53e686ea4ce380bf2166617055045ea25ab6e48dae142475eR1-R18) [[7]](diffhunk://#diff-e74ceb32c27f843b5137c2abc2d8a1dc1d7c8814705c951fcc9810d91c74f5f0R1-R13) [[8]](diffhunk://#diff-41a344c0b3955e2896f820ba3daeaff3dda499c06e57083dd544fe7f1e877593R1-R17) [[9]](diffhunk://#diff-983a28f68707b2e8f512b489c0a51a679b71b49d6f487f9c9a7ca52ec0926091R1-R18) [[10]](diffhunk://#diff-a9cc74465c277c80045156c82f69faeb56a8845eadb52615f8ad0dadf9b0e1bbR1-R18) [[11]](diffhunk://#diff-b96516fad046e9b0166164ca300a17e65b09ab7fc381201df563f752bd02d01dR1-R18) [[12]](diffhunk://#diff-768c8ee6bf47e0032bb95b108167d99e4d2d0ea6c652e614b2b8b1e0b620ba3cR1-R8)

This addition makes it easier to enforce maintainable, focused code by flagging overly large class-like structures and provides flexible configuration to suit different codebases.

Closes https://github.com/Orrison/MeliorStan/issues/40