### PR TITLE
Add ExcessiveParameterList rule with configuration, documentation, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ parameters:
 | **[DepthOfInheritance](docs/DepthOfInheritance.md)** | Detects classes with excessively deep inheritance chains | Classes |
 | **[ExcessiveClassLength](docs/ExcessiveClassLength.md)** | Detects classes, interfaces, traits, and enums with excessive line counts | Classes, Interfaces, Traits, Enums |
 | **[ExcessiveMethodLength](docs/ExcessiveMethodLength.md)** | Detects methods, functions, and closures with excessive line counts | Methods, Functions, Closures |
+| **[ExcessiveParameterList](docs/ExcessiveParameterList.md)** | Detects functions and methods with too many parameters | Functions, Methods, Closures, Arrow Functions |
 | **[ExcessivePublicCount](docs/ExcessivePublicCount.md)** | Detects classes with an excessive public API surface (public methods + properties) | Classes, Interfaces, Traits, Enums |
 | **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ parameters:
 | **[DepthOfInheritance](docs/DepthOfInheritance.md)** | Detects classes with excessively deep inheritance chains | Classes |
 | **[ExcessiveClassLength](docs/ExcessiveClassLength.md)** | Detects classes, interfaces, traits, and enums with excessive line counts | Classes, Interfaces, Traits, Enums |
 | **[ExcessiveMethodLength](docs/ExcessiveMethodLength.md)** | Detects methods, functions, and closures with excessive line counts | Methods, Functions, Closures |
-| **[ExcessiveParameterList](docs/ExcessiveParameterList.md)** | Detects functions and methods with too many parameters | Functions, Methods, Closures, Arrow Functions |
+| **[ExcessiveParameterList](docs/ExcessiveParameterList.md)** | Detects functions, methods, closures, and arrow functions with too many parameters | Functions, Methods, Closures, Arrow Functions |
 | **[ExcessivePublicCount](docs/ExcessivePublicCount.md)** | Detects classes with an excessive public API surface (public methods + properties) | Classes, Interfaces, Traits, Enums |
 | **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -129,6 +129,10 @@ parametersSchema:
             ignore_whitespace: bool(),
             ignore_pattern: string(),
         ]),
+        excessive_parameter_list: structure([
+            maximum: int(),
+            ignore_pattern: string(),
+        ]),
     ])
 
 # default parameters
@@ -234,6 +238,9 @@ parameters:
         excessive_class_length:
             maximum: 1000
             ignore_whitespace: false
+            ignore_pattern: ''
+        excessive_parameter_list:
+            maximum: 10
             ignore_pattern: ''
 
 services:
@@ -398,3 +405,8 @@ services:
             - %meliorstan.excessive_class_length.maximum%
             - %meliorstan.excessive_class_length.ignore_whitespace%
             - %meliorstan.excessive_class_length.ignore_pattern%
+    -
+        factory: Orrison\MeliorStan\Rules\ExcessiveParameterList\Config
+        arguments:
+            - %meliorstan.excessive_parameter_list.maximum%
+            - %meliorstan.excessive_parameter_list.ignore_pattern%

--- a/docs/ExcessiveParameterList.md
+++ b/docs/ExcessiveParameterList.md
@@ -1,0 +1,167 @@
+# ExcessiveParameterList
+
+This rule detects functions, methods, closures, and arrow functions whose parameter count exceeds a configurable threshold.
+
+Functions and methods with too many parameters are difficult to call, test, and maintain. A long parameter list is often a sign that related data should be encapsulated into a value object or data transfer object (DTO).
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `maximum`
+- **Type**: `int`
+- **Default**: `10`
+- **Description**: The maximum number of parameters a function, method, closure, or arrow function may declare before the rule reports an error.
+
+### `ignore_pattern`
+- **Type**: `string`
+- **Default**: `''`
+- **Description**: A regular expression pattern (without delimiters) matched against method or function names. When a name matches, the declaration is skipped. Useful for methods that legitimately accept many parameters, such as Laravel factory definitions (`definition`) or event listeners. Set to an empty string to apply the rule to all names. Closures and arrow functions have no name and are never ignored by this option.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveParameterList\ExcessiveParameterListRule
+
+parameters:
+    meliorstan:
+        excessive_parameter_list:
+            maximum: 10
+            ignore_pattern: ''
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class OrderService
+{
+    public function createOrder(
+        int $userId,
+        string $sku,
+        int $quantity,
+        string $currency,
+        string $shippingAddress,
+        string $billingAddress,
+        ?string $couponCode,
+        bool $sendConfirmation,
+        ?string $notes,
+        bool $priority,
+        string $channel,
+    ): Order {
+        // ...
+    }
+    // ✗ Error: Method "createOrder" has 11 parameters, which exceeds the maximum of 10.
+    //   Consider grouping parameters into a value object.
+
+    public function findById(int $id): ?Order
+    {
+        return $this->repository->find($id);
+    }
+    // ✓ Valid - 1 parameter
+
+    public function cancel(int $orderId, string $reason): void
+    {
+        // ...
+    }
+    // ✓ Valid - 2 parameters
+}
+
+function buildReport(
+    string $title,
+    array $rows,
+    string $format,
+    bool $includeHeaders,
+    bool $includeTotals,
+    string $locale,
+    string $timezone,
+    ?string $footer,
+    bool $landscape,
+    bool $compress,
+    string $encoding,
+): string {
+    // ...
+}
+// ✗ Error: Function "buildReport" has 11 parameters, which exceeds the maximum of 10.
+//   Consider grouping parameters into a value object.
+```
+
+### Configuration Examples
+
+#### Custom Maximum
+
+```neon
+parameters:
+    meliorstan:
+        excessive_parameter_list:
+            maximum: 5
+```
+
+```php
+<?php
+
+class UserService
+{
+    public function create(
+        string $name,
+        string $email,
+        string $password,
+        string $role,
+        bool $active,
+        string $locale,
+    ): User {
+        // ...
+    }
+    // ✗ Error: Method "create" has 6 parameters, which exceeds the maximum of 5.
+    //   Consider grouping parameters into a value object.
+}
+```
+
+#### Ignore Pattern (Laravel-friendly)
+
+```neon
+parameters:
+    meliorstan:
+        excessive_parameter_list:
+            ignore_pattern: '^(definition|handle)$'
+```
+
+```php
+<?php
+
+class UserFactory extends Factory
+{
+    public function definition(
+        string $name,
+        string $email,
+        string $password,
+        string $role,
+        bool $active,
+        string $locale,
+        string $timezone,
+        string $locale2,
+        string $timezone2,
+        bool $verified,
+        string $avatar,
+    ): array {
+        // ...
+    }
+    // ✓ Now valid - "definition" matches the ignore pattern
+}
+```
+
+## Important Notes
+
+- The rule applies to class methods (including `__construct` and abstract methods), standalone functions, closures (`function () { ... }`), and arrow functions (`fn () => ...`).
+- Interface method signatures are also checked, as the parameter list is part of the contract's design.
+- The `ignore_pattern` is case-insensitive and pattern delimiters (`/`) are added automatically — only provide the pattern itself.
+- Closures and arrow functions have no name and are never affected by `ignore_pattern`.

--- a/src/Rules/ExcessiveParameterList/Config.php
+++ b/src/Rules/ExcessiveParameterList/Config.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ExcessiveParameterList;
+
+class Config
+{
+    public function __construct(
+        protected int $maximum = 10,
+        protected string $ignorePattern = '',
+    ) {}
+
+    public function getMaximum(): int
+    {
+        return $this->maximum;
+    }
+
+    public function getIgnorePattern(): string
+    {
+        return $this->ignorePattern;
+    }
+}

--- a/src/Rules/ExcessiveParameterList/ExcessiveParameterListRule.php
+++ b/src/Rules/ExcessiveParameterList/ExcessiveParameterListRule.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\ExcessiveParameterList;
+
+use InvalidArgumentException;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FunctionLike>
+ */
+class ExcessiveParameterListRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = '%s has %d parameters, which exceeds the maximum of %d. Consider grouping parameters into a value object.';
+
+    public function __construct(
+        protected Config $config,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return FunctionLike::class;
+    }
+
+    /**
+     * @param FunctionLike $node
+     *
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $name = $this->getName($node);
+
+        if ($name !== null && $this->shouldIgnoreByPattern($name)) {
+            return [];
+        }
+
+        $paramCount = count($node->getParams());
+
+        if ($paramCount <= $this->config->getMaximum()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(self::ERROR_MESSAGE_TEMPLATE, $this->describeNode($node, $name), $paramCount, $this->config->getMaximum())
+            )
+                ->identifier('MeliorStan.excessiveParameterList')
+                ->build(),
+        ];
+    }
+
+    protected function getName(FunctionLike $node): ?string
+    {
+        if ($node instanceof ClassMethod || $node instanceof Function_) {
+            return $node->name->toString();
+        }
+
+        return null;
+    }
+
+    protected function shouldIgnoreByPattern(string $name): bool
+    {
+        $pattern = $this->config->getIgnorePattern();
+
+        if ($pattern === '') {
+            return false;
+        }
+
+        $regex = '/' . $pattern . '/i';
+
+        $result = @preg_match($regex, $name);
+
+        if ($result === false || preg_last_error() !== PREG_NO_ERROR) {
+            $error = preg_last_error_msg();
+
+            throw new InvalidArgumentException(
+                sprintf('Invalid regex pattern in ignore_pattern configuration: "%s". Error: %s', $pattern, $error)
+            );
+        }
+
+        return $result === 1;
+    }
+
+    protected function describeNode(FunctionLike $node, ?string $name): string
+    {
+        if ($node instanceof ClassMethod) {
+            return sprintf('Method "%s"', $name);
+        }
+
+        if ($node instanceof Function_) {
+            return sprintf('Function "%s"', $name);
+        }
+
+        if ($node instanceof ArrowFunction) {
+            return 'Arrow function';
+        }
+
+        return 'Closure';
+    }
+}

--- a/tests/Rules/ExcessiveParameterList/DefaultOptionsTest.php
+++ b/tests/Rules/ExcessiveParameterList/DefaultOptionsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveParameterList;
+
+use Orrison\MeliorStan\Rules\ExcessiveParameterList\ExcessiveParameterListRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessiveParameterListRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testClassMethodTriggers(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ManyParamMethod.php'],
+            [
+                [
+                    sprintf(ExcessiveParameterListRule::ERROR_MESSAGE_TEMPLATE, 'Method "tooManyParams"', 4, 3),
+                    7,
+                ],
+            ]
+        );
+    }
+
+    public function testFewParamsNoError(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/FewParamMethod.php'], []);
+    }
+
+    public function testStandaloneFunctionTriggers(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ManyParamFunction.php'],
+            [
+                [
+                    sprintf(ExcessiveParameterListRule::ERROR_MESSAGE_TEMPLATE, 'Function "manyParamFunction"', 4, 3),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    public function testClosureTriggers(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ManyParamClosure.php'],
+            [
+                [
+                    sprintf(ExcessiveParameterListRule::ERROR_MESSAGE_TEMPLATE, 'Closure', 4, 3),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    public function testArrowFunctionTriggers(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ManyParamArrowFunction.php'],
+            [
+                [
+                    sprintf(ExcessiveParameterListRule::ERROR_MESSAGE_TEMPLATE, 'Arrow function', 4, 3),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    public function testAbstractMethodTriggers(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/AbstractMethodManyParams.php'],
+            [
+                [
+                    sprintf(ExcessiveParameterListRule::ERROR_MESSAGE_TEMPLATE, 'Method "tooManyParams"', 4, 3),
+                    7,
+                ],
+            ]
+        );
+    }
+
+    public function testInterfaceMethodTriggers(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/InterfaceManyParams.php'],
+            [
+                [
+                    sprintf(ExcessiveParameterListRule::ERROR_MESSAGE_TEMPLATE, 'Method "tooManyParams"', 4, 3),
+                    7,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/default.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessiveParameterListRule::class);
+    }
+}

--- a/tests/Rules/ExcessiveParameterList/Fixture/AbstractMethodManyParams.php
+++ b/tests/Rules/ExcessiveParameterList/Fixture/AbstractMethodManyParams.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveParameterList\Fixture;
+
+abstract class AbstractMethodManyParams
+{
+    abstract public function tooManyParams(int $a, int $b, int $c, int $d): void;
+}

--- a/tests/Rules/ExcessiveParameterList/Fixture/FewParamMethod.php
+++ b/tests/Rules/ExcessiveParameterList/Fixture/FewParamMethod.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveParameterList\Fixture;
+
+class FewParamMethod
+{
+    public function fewParams(int $a, int $b): void {}
+}

--- a/tests/Rules/ExcessiveParameterList/Fixture/IgnoredMethodByPattern.php
+++ b/tests/Rules/ExcessiveParameterList/Fixture/IgnoredMethodByPattern.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveParameterList\Fixture;
+
+class IgnoredMethodByPattern
+{
+    public function ignoredMethod(int $a, int $b, int $c, int $d): void {}
+}

--- a/tests/Rules/ExcessiveParameterList/Fixture/InterfaceManyParams.php
+++ b/tests/Rules/ExcessiveParameterList/Fixture/InterfaceManyParams.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveParameterList\Fixture;
+
+interface InterfaceManyParams
+{
+    public function tooManyParams(int $a, int $b, int $c, int $d): void;
+}

--- a/tests/Rules/ExcessiveParameterList/Fixture/ManyParamArrowFunction.php
+++ b/tests/Rules/ExcessiveParameterList/Fixture/ManyParamArrowFunction.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveParameterList\Fixture;
+
+$arrowFn = fn (int $a, int $b, int $c, int $d) => $a + $b + $c + $d;

--- a/tests/Rules/ExcessiveParameterList/Fixture/ManyParamClosure.php
+++ b/tests/Rules/ExcessiveParameterList/Fixture/ManyParamClosure.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveParameterList\Fixture;
+
+$closure = function (int $a, int $b, int $c, int $d): void {};

--- a/tests/Rules/ExcessiveParameterList/Fixture/ManyParamFunction.php
+++ b/tests/Rules/ExcessiveParameterList/Fixture/ManyParamFunction.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveParameterList\Fixture;
+
+function manyParamFunction(int $a, int $b, int $c, int $d): void {}

--- a/tests/Rules/ExcessiveParameterList/Fixture/ManyParamMethod.php
+++ b/tests/Rules/ExcessiveParameterList/Fixture/ManyParamMethod.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveParameterList\Fixture;
+
+class ManyParamMethod
+{
+    public function tooManyParams(int $a, int $b, int $c, int $d): void {}
+}

--- a/tests/Rules/ExcessiveParameterList/IgnorePatternTest.php
+++ b/tests/Rules/ExcessiveParameterList/IgnorePatternTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveParameterList;
+
+use Orrison\MeliorStan\Rules\ExcessiveParameterList\ExcessiveParameterListRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessiveParameterListRule>
+ */
+class IgnorePatternTest extends RuleTestCase
+{
+    public function testIgnoredMethodSkipped(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/IgnoredMethodByPattern.php'], []);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignore_pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessiveParameterListRule::class);
+    }
+}

--- a/tests/Rules/ExcessiveParameterList/InvalidPatternTest.php
+++ b/tests/Rules/ExcessiveParameterList/InvalidPatternTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\ExcessiveParameterList;
+
+use InvalidArgumentException;
+use Orrison\MeliorStan\Rules\ExcessiveParameterList\ExcessiveParameterListRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ExcessiveParameterListRule>
+ */
+class InvalidPatternTest extends RuleTestCase
+{
+    public function testInvalidPattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid regex pattern in ignore_pattern configuration');
+
+        $this->analyse([
+            __DIR__ . '/Fixture/ManyParamMethod.php',
+        ], []);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/invalid-pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ExcessiveParameterListRule::class);
+    }
+}

--- a/tests/Rules/ExcessiveParameterList/config/default.neon
+++ b/tests/Rules/ExcessiveParameterList/config/default.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveParameterList\ExcessiveParameterListRule
+
+parameters:
+    meliorstan:
+        excessive_parameter_list:
+            maximum: 3
+            ignore_pattern: ''

--- a/tests/Rules/ExcessiveParameterList/config/ignore_pattern.neon
+++ b/tests/Rules/ExcessiveParameterList/config/ignore_pattern.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveParameterList\ExcessiveParameterListRule
+
+parameters:
+    meliorstan:
+        excessive_parameter_list:
+            maximum: 3
+            ignore_pattern: 'ignored'

--- a/tests/Rules/ExcessiveParameterList/config/invalid-pattern.neon
+++ b/tests/Rules/ExcessiveParameterList/config/invalid-pattern.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\ExcessiveParameterList\ExcessiveParameterListRule
+
+parameters:
+    meliorstan:
+        excessive_parameter_list:
+            maximum: 3
+            ignore_pattern: '/invalid[regex'


### PR DESCRIPTION
This pull request introduces a new "ExcessiveParameterList" rule to the codebase, which detects functions, methods, closures, and arrow functions that have too many parameters. The rule is configurable and integrates with the existing PHPStan extension structure. Comprehensive documentation and a suite of tests are provided to ensure correct behavior and ease of adoption.

**New Rule: ExcessiveParameterList**

* Adds the `ExcessiveParameterList` rule to detect and report functions/methods with parameter counts exceeding a configurable maximum. The rule supports an `ignore_pattern` option to skip specified function/method names. [[1]](diffhunk://#diff-30b51494031bd7722075b0bab2a3cc7e61e4f0815c343e0c708536df613e4f39R1-R108) [[2]](diffhunk://#diff-7f45931b65684aef1da4de93e1c4e74aece99a2e80e86a3e4dc56b4d0025426bR1-R21)
* Documents the rule, its configuration options, usage, and examples in a new `docs/ExcessiveParameterList.md` file.
* Updates the `README.md` to include the new rule in the list of available rules.

**Configuration and Integration**

* Updates `config/extension.neon` to define schema, default parameters, and service wiring for the new rule, including `maximum` and `ignore_pattern` options. [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R132-R135) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R242-R244) [[3]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R408-R412)

**Testing**

* Adds a suite of tests for the new rule, including default behavior, ignore pattern functionality, and various code fixtures (methods, functions, closures, arrow functions, interface/abstract methods). Test configuration files are included for different scenarios. [[1]](diffhunk://#diff-4ab5c9005f603b60d06095b01a61f61bd2ceb80f652bf6402088413e1117f8b0R1-R106) [[2]](diffhunk://#diff-141b4c5f02a19ba1a2028b55d44c91676298cada8ea000b2e837ad83481ef1aeR1-R28) [[3]](diffhunk://#diff-3fc731a6592ccd225524588bf53ad3a10964a1f2278d4c8bb4b2c582cce275b4R1-R11) [[4]](diffhunk://#diff-9347e91afb8d3363d5843adf5f5bbddbe386621b4a152ecfba112e99af915e46R1-R11) [[5]](diffhunk://#diff-b36a1f91d895b86610f3a0703fdf5dd5b2399099340d0cd630a926b2663fd4beR1-R8) [[6]](diffhunk://#diff-dabe3043f4ddc735eecaf1b7e5d17680c2078b7204179ae50ea32dbbc18fa541R1-R8) [[7]](diffhunk://#diff-9f9523b33e165aa6e0bc8c96ef1374f8872fccadceb37cffba3e09219f11a6deR1-R8) [[8]](diffhunk://#diff-e5c35a0a5ac357c798e65f825e2a4067b7af38040878398d4cdd569f86cfdaf9R1-R8) [[9]](diffhunk://#diff-d15b92b40e1de59c9a770477860bdf8b011fd138ad67372943f652611a947e13R1-R5) [[10]](diffhunk://#diff-f148bae9f3182401a01f9621f9c06f7e923ce446c077f5aacce35d7ee7bc2aecR1-R5) [[11]](diffhunk://#diff-255347cf11958a56ab9845831eef8f979a954a18b8421ae9ec04cb11abb16383R1-R5) [[12]](diffhunk://#diff-c365350f695a555faf167f3aa39f702e75da22339a7defd9e3513eb67f2d3d09R1-R8)

Closes https://github.com/Orrison/MeliorStan/issues/41