### PR TITLE
Add NPath complexity rule to MeliorStan

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ parameters:
 | **[ExcessiveParameterList](docs/ExcessiveParameterList.md)** | Detects functions, methods, closures, and arrow functions with too many parameters | Functions, Methods, Closures, Arrow Functions |
 | **[ExcessivePublicCount](docs/ExcessivePublicCount.md)** | Detects classes with an excessive public API surface (public methods + properties) | Classes, Interfaces, Traits, Enums |
 | **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |
+| **[NpathComplexity](docs/NpathComplexity.md)** | Detects methods and functions with high NPath complexity (number of acyclic execution paths) | Methods, Functions |
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |
 | **[StaticAccess](docs/StaticAccess.md)** | Detects static method calls and optionally static property access that create tight coupling | Static Access |
 | **[TooManyFields](docs/TooManyFields.md)** | Detects classes and traits with an excessive number of instance fields | Classes, Traits |

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -137,6 +137,10 @@ parametersSchema:
             maximum: int(),
             ignore_pattern: string(),
         ]),
+        npath_complexity: structure([
+            maximum: int(),
+            ignore_pattern: string(),
+        ]),
     ])
 
 # default parameters
@@ -248,6 +252,9 @@ parameters:
             ignore_pattern: ''
         excessive_class_complexity:
             maximum: 50
+            ignore_pattern: ''
+        npath_complexity:
+            maximum: 200
             ignore_pattern: ''
 
 services:
@@ -418,8 +425,14 @@ services:
             - %meliorstan.excessive_parameter_list.maximum%
             - %meliorstan.excessive_parameter_list.ignore_pattern%
     - Orrison\MeliorStan\Support\CyclomaticComplexityCalculator
+    - Orrison\MeliorStan\Support\NpathComplexityCalculator
     -
         factory: Orrison\MeliorStan\Rules\ExcessiveClassComplexity\Config
         arguments:
             - %meliorstan.excessive_class_complexity.maximum%
             - %meliorstan.excessive_class_complexity.ignore_pattern%
+    -
+        factory: Orrison\MeliorStan\Rules\NpathComplexity\Config
+        arguments:
+            - %meliorstan.npath_complexity.maximum%
+            - %meliorstan.npath_complexity.ignore_pattern%

--- a/docs/NpathComplexity.md
+++ b/docs/NpathComplexity.md
@@ -1,0 +1,142 @@
+# NpathComplexity
+
+This rule detects methods and functions with high NPath complexity, which measures the number of acyclic execution paths through the code.
+
+NPath complexity differs fundamentally from cyclomatic complexity: instead of adding one point per decision, it **multiplies** the path count across sequential decision structures. Two independent `if` statements produce an NPath of 4 (2 × 2), not 3 like cyclomatic complexity. This exponential growth makes NPath a sensitive measure of how many distinct paths a test suite must exercise to achieve full coverage.
+
+A method with NPath complexity of 200 has 200 distinct acyclic paths — requiring 200 test cases for full coverage.
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `maximum`
+- **Type**: `int`
+- **Default**: `200`
+- **Description**: The NPath complexity threshold. Methods and functions with NPath complexity exceeding this value will trigger an error. The default of 200 matches the PHPMD standard.
+
+### `ignore_pattern`
+- **Type**: `string`
+- **Default**: `''`
+- **Description**: A regex pattern matched against the method or function **name** (case-insensitive). Matching methods and functions are skipped. Useful for excluding known-complex entry points, generated code handlers, or specific lifecycle methods. Example: `^(setUp|tearDown|boot)` skips common Laravel/PHPUnit lifecycle methods.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\NpathComplexity\NpathComplexityRule
+
+parameters:
+    meliorstan:
+        npath_complexity:
+            maximum: 200
+            ignore_pattern: ''
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class OrderService
+{
+    // ✓ Valid - NPath: 4 (two independent ifs: 2 × 2)
+    public function validateOrder(Order $order): bool
+    {
+        if ($order->isExpired()) {
+            return false;
+        }
+
+        if ($order->amount <= 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    // ✗ Error: Method processOrder() has an NPath complexity of 256. The configured maximum is 200.
+    // Eight independent if statements: 2^8 = 256 paths
+    public function processOrder(Order $order): void
+    {
+        if ($order->hasDiscount()) { /* ... */ }
+        if ($order->isRush()) { /* ... */ }
+        if ($order->needsApproval()) { /* ... */ }
+        if ($order->isInternational()) { /* ... */ }
+        if ($order->hasTax()) { /* ... */ }
+        if ($order->isSubscription()) { /* ... */ }
+        if ($order->hasGiftCard()) { /* ... */ }
+        if ($order->requiresSignature()) { /* ... */ }
+    }
+}
+
+// ✗ Error: Function importData() has an NPath complexity of 256. The configured maximum is 200.
+function importData(array $row): void
+{
+    if (isset($row['field1'])) { /* ... */ }
+    if (isset($row['field2'])) { /* ... */ }
+    if (isset($row['field3'])) { /* ... */ }
+    if (isset($row['field4'])) { /* ... */ }
+    if (isset($row['field5'])) { /* ... */ }
+    if (isset($row['field6'])) { /* ... */ }
+    if (isset($row['field7'])) { /* ... */ }
+    if (isset($row['field8'])) { /* ... */ }
+}
+```
+
+### Configuration Examples
+
+#### Custom Threshold
+
+```neon
+parameters:
+    meliorstan:
+        npath_complexity:
+            maximum: 50
+```
+
+```php
+// ✗ Error: Method resolve() has an NPath complexity of 64. The configured maximum is 50.
+public function resolve(Request $request): Response
+{
+    if ($request->isGet()) { /* ... */ }
+    if ($request->isPost()) { /* ... */ }
+    if ($request->isAuthenticated()) { /* ... */ }
+    if ($request->hasCsrf()) { /* ... */ }
+    if ($request->isJson()) { /* ... */ }
+    if ($request->isSecure()) { /* ... */ }
+    // NPath = 2^6 = 64
+}
+```
+
+#### Ignore Pattern
+
+```neon
+parameters:
+    meliorstan:
+        npath_complexity:
+            ignore_pattern: '^(setUp|tearDown|boot|handle)'
+```
+
+```php
+// ✓ Now valid — name matches ignore_pattern
+public function handle(Request $request, Closure $next): Response
+{
+    // Complex middleware logic with many checks
+}
+```
+
+## Important Notes
+
+- The rule applies to named class methods and named standalone functions only; anonymous functions (closures) and arrow functions are treated as atomic and do not contribute to the NPath of their containing method
+- NPath complexity grows **exponentially** with sequential decision structures: 8 independent `if` statements produce NPath 256 (2^8), while nesting them gives much lower values
+- NPath considers: `if`/`elseif`/`else`, `while`, `do-while`, `for`, `foreach`, `switch`/`case`, `try`/`catch`, ternary (`?:`), null coalesce (`??`), logical operators (`&&`, `||`, `and`, `or`), and PHP 8 `match` expressions
+- `match` arms are counted similarly to `switch` cases; a `match` without a `default` arm adds one extra path (for the `UnhandledMatchError` case)
+- The `ignore_pattern` matches against the method or function name, not the class name
+- Consider refactoring by extracting private helper methods, using early returns, or splitting complex methods into smaller, focused units

--- a/src/Rules/NpathComplexity/Config.php
+++ b/src/Rules/NpathComplexity/Config.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\NpathComplexity;
+
+class Config
+{
+    public function __construct(
+        protected int $maximum = 200,
+        protected string $ignorePattern = '',
+    ) {}
+
+    public function getMaximum(): int
+    {
+        return $this->maximum;
+    }
+
+    public function getIgnorePattern(): string
+    {
+        return $this->ignorePattern;
+    }
+}

--- a/src/Rules/NpathComplexity/NpathComplexityRule.php
+++ b/src/Rules/NpathComplexity/NpathComplexityRule.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\NpathComplexity;
+
+use InvalidArgumentException;
+use Orrison\MeliorStan\Support\NpathComplexityCalculator;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FunctionLike>
+ */
+class NpathComplexityRule implements Rule
+{
+    public const string ERROR_MESSAGE_TEMPLATE = '%s %s() has an NPath complexity of %d. The configured maximum is %d.';
+
+    public function __construct(
+        protected Config $config,
+        protected NpathComplexityCalculator $calculator,
+    ) {}
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return FunctionLike::class;
+    }
+
+    /**
+     * @param FunctionLike $node
+     *
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node instanceof Closure || $node instanceof ArrowFunction) {
+            return [];
+        }
+
+        if (! ($node instanceof ClassMethod || $node instanceof Function_)) {
+            return [];
+        }
+
+        $name = $node->name->toString();
+
+        if ($this->shouldIgnoreByPattern($name)) {
+            return [];
+        }
+
+        $complexity = $this->calculator->calculate($node);
+
+        if ($complexity <= $this->config->getMaximum()) {
+            return [];
+        }
+
+        $type = $node instanceof ClassMethod ? 'Method' : 'Function';
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(self::ERROR_MESSAGE_TEMPLATE, $type, $name, $complexity, $this->config->getMaximum())
+            )
+                ->identifier('MeliorStan.npathComplexity')
+                ->build(),
+        ];
+    }
+
+    protected function shouldIgnoreByPattern(string $name): bool
+    {
+        $pattern = $this->config->getIgnorePattern();
+
+        if ($pattern === '') {
+            return false;
+        }
+
+        $regex = '/' . $pattern . '/i';
+
+        $result = @preg_match($regex, $name);
+
+        if ($result === false || preg_last_error() !== PREG_NO_ERROR) {
+            $error = preg_last_error_msg();
+
+            throw new InvalidArgumentException(
+                sprintf('Invalid regex pattern in ignore_pattern configuration: "%s". Error: %s', $pattern, $error)
+            );
+        }
+
+        return $result === 1;
+    }
+}

--- a/src/Rules/NpathComplexity/NpathComplexityRule.php
+++ b/src/Rules/NpathComplexity/NpathComplexityRule.php
@@ -22,6 +22,8 @@ class NpathComplexityRule implements Rule
 {
     public const string ERROR_MESSAGE_TEMPLATE = '%s %s() has an NPath complexity of %d. The configured maximum is %d.';
 
+    public const string ERROR_MESSAGE_OVERFLOW = '%s %s() has an NPath complexity that exceeds the maximum representable value. The configured maximum is %d.';
+
     public function __construct(
         protected Config $config,
         protected NpathComplexityCalculator $calculator,
@@ -63,6 +65,16 @@ class NpathComplexityRule implements Rule
         }
 
         $type = $node instanceof ClassMethod ? 'Method' : 'Function';
+
+        if ($complexity === PHP_INT_MAX) {
+            return [
+                RuleErrorBuilder::message(
+                    sprintf(self::ERROR_MESSAGE_OVERFLOW, $type, $name, $this->config->getMaximum())
+                )
+                    ->identifier('MeliorStan.npathComplexity')
+                    ->build(),
+            ];
+        }
 
         return [
             RuleErrorBuilder::message(

--- a/src/Support/NpathComplexityCalculator.php
+++ b/src/Support/NpathComplexityCalculator.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Orrison\MeliorStan\Support;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use PhpParser\Node\Expr\BinaryOp\Coalesce;
+use PhpParser\Node\Expr\BinaryOp\LogicalAnd;
+use PhpParser\Node\Expr\BinaryOp\LogicalOr;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\Match_;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt\Switch_;
+use PhpParser\Node\Stmt\TryCatch;
+use PhpParser\Node\Stmt\While_;
+
+class NpathComplexityCalculator
+{
+    public function calculate(FunctionLike $node): int
+    {
+        return $this->calculateStmtList($node->getStmts() ?? []);
+    }
+
+    /**
+     * @param Node\Stmt[] $stmts
+     */
+    protected function calculateStmtList(array $stmts): int
+    {
+        $npath = 1;
+
+        foreach ($stmts as $stmt) {
+            $npath *= $this->calculateStmt($stmt);
+        }
+
+        return max(1, $npath);
+    }
+
+    protected function calculateStmt(Node $stmt): int
+    {
+        if ($stmt instanceof If_) {
+            return $this->calculateIf($stmt);
+        }
+
+        if ($stmt instanceof While_) {
+            return $this->countConditionPaths($stmt->cond) + $this->calculateStmtList($stmt->stmts) + 1;
+        }
+
+        if ($stmt instanceof Do_) {
+            return $this->countConditionPaths($stmt->cond) + $this->calculateStmtList($stmt->stmts) + 1;
+        }
+
+        if ($stmt instanceof For_) {
+            $condPaths = 0;
+
+            foreach ($stmt->cond as $cond) {
+                $condPaths += $this->countConditionPaths($cond);
+            }
+
+            return $condPaths + $this->calculateStmtList($stmt->stmts) + 1;
+        }
+
+        if ($stmt instanceof Foreach_) {
+            return $this->calculateStmtList($stmt->stmts) + 1;
+        }
+
+        if ($stmt instanceof Switch_) {
+            return $this->calculateSwitch($stmt);
+        }
+
+        if ($stmt instanceof TryCatch) {
+            return $this->calculateTryCatch($stmt);
+        }
+
+        if ($stmt instanceof Return_) {
+            return $stmt->expr !== null ? $this->calculateExprPaths($stmt->expr) : 1;
+        }
+
+        if ($stmt instanceof Expression) {
+            return $this->calculateExprPaths($stmt->expr);
+        }
+
+        return 1;
+    }
+
+    protected function calculateIf(If_ $if): int
+    {
+        $npath = $this->countConditionPaths($if->cond) + $this->calculateStmtList($if->stmts);
+
+        foreach ($if->elseifs as $elseif) {
+            $npath += $this->countConditionPaths($elseif->cond) + $this->calculateStmtList($elseif->stmts);
+        }
+
+        if ($if->else !== null) {
+            $npath += $this->calculateStmtList($if->else->stmts);
+        } else {
+            $npath += 1;
+        }
+
+        return max(1, $npath);
+    }
+
+    protected function calculateSwitch(Switch_ $switch): int
+    {
+        $hasDefault = false;
+        $npath = 0;
+
+        foreach ($switch->cases as $case) {
+            if ($case->cond === null) {
+                $hasDefault = true;
+            }
+
+            $npath += max(1, $this->calculateStmtList($case->stmts));
+        }
+
+        if (! $hasDefault) {
+            $npath += 1;
+        }
+
+        return max(1, $npath);
+    }
+
+    protected function calculateTryCatch(TryCatch $tryCatch): int
+    {
+        $npath = $this->calculateStmtList($tryCatch->stmts);
+
+        foreach ($tryCatch->catches as $catch) {
+            $npath += $this->calculateStmtList($catch->stmts);
+        }
+
+        return max(1, $npath);
+    }
+
+    protected function countConditionPaths(Node\Expr $expr): int
+    {
+        if ($expr instanceof Closure || $expr instanceof ArrowFunction) {
+            return 0;
+        }
+
+        $count = ($expr instanceof BooleanAnd || $expr instanceof BooleanOr
+            || $expr instanceof LogicalAnd || $expr instanceof LogicalOr) ? 1 : 0;
+
+        foreach ($expr->getSubNodeNames() as $subNodeName) {
+            $subNode = $expr->{$subNodeName};
+
+            if ($subNode instanceof Node\Expr) {
+                $count += $this->countConditionPaths($subNode);
+            } elseif (is_array($subNode)) {
+                foreach ($subNode as $item) {
+                    if ($item instanceof Node\Expr) {
+                        $count += $this->countConditionPaths($item);
+                    }
+                }
+            }
+        }
+
+        return $count;
+    }
+
+    protected function calculateExprPaths(Node\Expr $expr): int
+    {
+        if ($expr instanceof Closure || $expr instanceof ArrowFunction) {
+            return 1;
+        }
+
+        if ($expr instanceof Ternary) {
+            $thenPaths = $expr->if !== null ? $this->calculateExprPaths($expr->if) : 1;
+
+            return $thenPaths + $this->calculateExprPaths($expr->else);
+        }
+
+        if ($expr instanceof Coalesce) {
+            return $this->calculateExprPaths($expr->left) + $this->calculateExprPaths($expr->right);
+        }
+
+        if ($expr instanceof Match_) {
+            return $this->calculateMatchPaths($expr);
+        }
+
+        $total = 1;
+
+        foreach ($expr->getSubNodeNames() as $subNodeName) {
+            $subNode = $expr->{$subNodeName};
+
+            if ($subNode instanceof Node\Expr) {
+                $subPaths = $this->calculateExprPaths($subNode);
+
+                if ($subPaths > 1) {
+                    $total += $subPaths - 1;
+                }
+            } elseif (is_array($subNode)) {
+                foreach ($subNode as $item) {
+                    if ($item instanceof Node\Expr) {
+                        $subPaths = $this->calculateExprPaths($item);
+
+                        if ($subPaths > 1) {
+                            $total += $subPaths - 1;
+                        }
+                    } elseif ($item instanceof Node\Arg) {
+                        $subPaths = $this->calculateExprPaths($item->value);
+
+                        if ($subPaths > 1) {
+                            $total += $subPaths - 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $total;
+    }
+
+    protected function calculateMatchPaths(Match_ $match): int
+    {
+        $hasDefault = false;
+        $total = 0;
+
+        foreach ($match->arms as $arm) {
+            if ($arm->conds === null) {
+                $hasDefault = true;
+            }
+
+            $total += $this->calculateExprPaths($arm->body);
+        }
+
+        if (! $hasDefault) {
+            $total += 1;
+        }
+
+        return max(1, $total);
+    }
+}

--- a/src/Support/NpathComplexityCalculator.php
+++ b/src/Support/NpathComplexityCalculator.php
@@ -38,7 +38,13 @@ class NpathComplexityCalculator
         $npath = 1;
 
         foreach ($stmts as $stmt) {
-            $npath *= $this->calculateStmt($stmt);
+            $stmtNpath = $this->calculateStmt($stmt);
+
+            if ($stmtNpath > 1 && $npath > intdiv(PHP_INT_MAX, $stmtNpath)) {
+                return PHP_INT_MAX;
+            }
+
+            $npath *= $stmtNpath;
         }
 
         return max(1, $npath);
@@ -134,6 +140,16 @@ class NpathComplexityCalculator
 
         foreach ($tryCatch->catches as $catch) {
             $npath += $this->calculateStmtList($catch->stmts);
+        }
+
+        if ($tryCatch->finally !== null) {
+            $finallyNpath = $this->calculateStmtList($tryCatch->finally->stmts);
+
+            if ($finallyNpath > 1 && $npath > intdiv(PHP_INT_MAX, $finallyNpath)) {
+                return PHP_INT_MAX;
+            }
+
+            $npath *= $finallyNpath;
         }
 
         return max(1, $npath);

--- a/src/Support/NpathComplexityCalculator.php
+++ b/src/Support/NpathComplexityCalculator.php
@@ -188,9 +188,10 @@ class NpathComplexityCalculator
         }
 
         if ($expr instanceof Ternary) {
+            $condPaths = $this->countConditionPaths($expr->cond);
             $thenPaths = $expr->if !== null ? $this->calculateExprPaths($expr->if) : 1;
 
-            return $thenPaths + $this->calculateExprPaths($expr->else);
+            return $condPaths + $thenPaths + $this->calculateExprPaths($expr->else);
         }
 
         if ($expr instanceof Coalesce) {

--- a/src/Support/NpathComplexityCalculator.php
+++ b/src/Support/NpathComplexityCalculator.php
@@ -99,16 +99,25 @@ class NpathComplexityCalculator
 
     protected function calculateIf(If_ $if): int
     {
-        $npath = $this->countConditionPaths($if->cond) + $this->calculateStmtList($if->stmts);
+        $npath = $this->addSaturating(
+            $this->countConditionPaths($if->cond),
+            $this->calculateStmtList($if->stmts),
+        );
 
         foreach ($if->elseifs as $elseif) {
-            $npath += $this->countConditionPaths($elseif->cond) + $this->calculateStmtList($elseif->stmts);
+            $npath = $this->addSaturating(
+                $npath,
+                $this->addSaturating(
+                    $this->countConditionPaths($elseif->cond),
+                    $this->calculateStmtList($elseif->stmts),
+                ),
+            );
         }
 
         if ($if->else !== null) {
-            $npath += $this->calculateStmtList($if->else->stmts);
+            $npath = $this->addSaturating($npath, $this->calculateStmtList($if->else->stmts));
         } else {
-            $npath += 1;
+            $npath = $this->addSaturating($npath, 1);
         }
 
         return max(1, $npath);
@@ -124,11 +133,11 @@ class NpathComplexityCalculator
                 $hasDefault = true;
             }
 
-            $npath += max(1, $this->calculateStmtList($case->stmts));
+            $npath = $this->addSaturating($npath, max(1, $this->calculateStmtList($case->stmts)));
         }
 
         if (! $hasDefault) {
-            $npath += 1;
+            $npath = $this->addSaturating($npath, 1);
         }
 
         return max(1, $npath);
@@ -139,7 +148,7 @@ class NpathComplexityCalculator
         $npath = $this->calculateStmtList($tryCatch->stmts);
 
         foreach ($tryCatch->catches as $catch) {
-            $npath += $this->calculateStmtList($catch->stmts);
+            $npath = $this->addSaturating($npath, $this->calculateStmtList($catch->stmts));
         }
 
         if ($tryCatch->finally !== null) {
@@ -211,7 +220,7 @@ class NpathComplexityCalculator
                 $subPaths = $this->calculateExprPaths($subNode);
 
                 if ($subPaths > 1) {
-                    $total += $subPaths - 1;
+                    $total = $this->addSaturating($total, $subPaths - 1);
                 }
             } elseif (is_array($subNode)) {
                 foreach ($subNode as $item) {
@@ -219,13 +228,13 @@ class NpathComplexityCalculator
                         $subPaths = $this->calculateExprPaths($item);
 
                         if ($subPaths > 1) {
-                            $total += $subPaths - 1;
+                            $total = $this->addSaturating($total, $subPaths - 1);
                         }
                     } elseif ($item instanceof Node\Arg) {
                         $subPaths = $this->calculateExprPaths($item->value);
 
                         if ($subPaths > 1) {
-                            $total += $subPaths - 1;
+                            $total = $this->addSaturating($total, $subPaths - 1);
                         }
                     }
                 }
@@ -245,13 +254,22 @@ class NpathComplexityCalculator
                 $hasDefault = true;
             }
 
-            $total += $this->calculateExprPaths($arm->body);
+            $total = $this->addSaturating($total, $this->calculateExprPaths($arm->body));
         }
 
         if (! $hasDefault) {
-            $total += 1;
+            $total = $this->addSaturating($total, 1);
         }
 
         return max(1, $total);
+    }
+
+    protected function addSaturating(int $a, int $b): int
+    {
+        if ($b > PHP_INT_MAX - $a) {
+            return PHP_INT_MAX;
+        }
+
+        return $a + $b;
     }
 }

--- a/tests/Rules/NpathComplexity/CustomThresholdTest.php
+++ b/tests/Rules/NpathComplexity/CustomThresholdTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity;
+
+use Orrison\MeliorStan\Rules\NpathComplexity\NpathComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<NpathComplexityRule>
+ */
+class CustomThresholdTest extends RuleTestCase
+{
+    public function testMethodExceedingCustomThresholdTriggersError(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/MediumNpathClass.php'],
+            [
+                [
+                    sprintf(NpathComplexityRule::ERROR_MESSAGE_TEMPLATE, 'Method', 'moderateMethod', 64, 32),
+                    8,
+                ],
+            ]
+        );
+    }
+
+    public function testMethodUnderCustomThresholdNoError(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/LowNpathClass.php'], []);
+    }
+
+    public function testHighNpathMethodAlsoTriggersWithCustomThreshold(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/HighNpathClass.php'],
+            [
+                [
+                    sprintf(NpathComplexityRule::ERROR_MESSAGE_TEMPLATE, 'Method', 'processOrder', 256, 32),
+                    8,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/custom_threshold.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NpathComplexityRule::class);
+    }
+}

--- a/tests/Rules/NpathComplexity/DefaultOptionsTest.php
+++ b/tests/Rules/NpathComplexity/DefaultOptionsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity;
+
+use Orrison\MeliorStan\Rules\NpathComplexity\NpathComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<NpathComplexityRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testHighNpathMethodTriggersError(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/HighNpathClass.php'],
+            [
+                [
+                    sprintf(NpathComplexityRule::ERROR_MESSAGE_TEMPLATE, 'Method', 'processOrder', 256, 200),
+                    8,
+                ],
+            ]
+        );
+    }
+
+    public function testLowNpathMethodNoError(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/LowNpathClass.php'], []);
+    }
+
+    public function testHighNpathFunctionTriggersError(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/HighNpathFunction.php'],
+            [
+                [
+                    sprintf(NpathComplexityRule::ERROR_MESSAGE_TEMPLATE, 'Function', 'processData', 256, 200),
+                    6,
+                ],
+            ]
+        );
+    }
+
+    public function testMatchExpressionContributesToNpath(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/MatchExpressionClass.php'],
+            [
+                [
+                    sprintf(NpathComplexityRule::ERROR_MESSAGE_TEMPLATE, 'Method', 'processWithMatch', 2304, 200),
+                    8,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/default.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NpathComplexityRule::class);
+    }
+}

--- a/tests/Rules/NpathComplexity/Fixture/HighNpathClass.php
+++ b/tests/Rules/NpathComplexity/Fixture/HighNpathClass.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity\Fixture;
+
+class HighNpathClass
+{
+    // NPath = 2^8 = 256 (eight independent if statements)
+    public function processOrder(int $a, int $b, int $c, int $d, int $e, int $f, int $g, int $h): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+
+        if ($f > 0) {
+            echo 'f';
+        }
+
+        if ($g > 0) {
+            echo 'g';
+        }
+
+        if ($h > 0) {
+            echo 'h';
+        }
+    }
+}

--- a/tests/Rules/NpathComplexity/Fixture/HighNpathFunction.php
+++ b/tests/Rules/NpathComplexity/Fixture/HighNpathFunction.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity\Fixture;
+
+// NPath = 2^8 = 256 (eight independent if statements)
+function processData(int $a, int $b, int $c, int $d, int $e, int $f, int $g, int $h): void
+{
+    if ($a > 0) {
+        echo 'a';
+    }
+
+    if ($b > 0) {
+        echo 'b';
+    }
+
+    if ($c > 0) {
+        echo 'c';
+    }
+
+    if ($d > 0) {
+        echo 'd';
+    }
+
+    if ($e > 0) {
+        echo 'e';
+    }
+
+    if ($f > 0) {
+        echo 'f';
+    }
+
+    if ($g > 0) {
+        echo 'g';
+    }
+
+    if ($h > 0) {
+        echo 'h';
+    }
+}

--- a/tests/Rules/NpathComplexity/Fixture/IgnoredMethodClass.php
+++ b/tests/Rules/NpathComplexity/Fixture/IgnoredMethodClass.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity\Fixture;
+
+class IgnoredMethodClass
+{
+    // NPath = 256 but name matches ignore_pattern '^calculate'
+    public function calculateOrder(int $a, int $b, int $c, int $d, int $e, int $f, int $g, int $h): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+
+        if ($f > 0) {
+            echo 'f';
+        }
+
+        if ($g > 0) {
+            echo 'g';
+        }
+
+        if ($h > 0) {
+            echo 'h';
+        }
+    }
+}

--- a/tests/Rules/NpathComplexity/Fixture/LowNpathClass.php
+++ b/tests/Rules/NpathComplexity/Fixture/LowNpathClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity\Fixture;
+
+class LowNpathClass
+{
+    // NPath = 4 (two independent if statements)
+    public function simpleMethod(int $a, int $b): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+    }
+}

--- a/tests/Rules/NpathComplexity/Fixture/MatchExpressionClass.php
+++ b/tests/Rules/NpathComplexity/Fixture/MatchExpressionClass.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity\Fixture;
+
+class MatchExpressionClass
+{
+    // NPath: match has 8 arms (no default) = 9 paths; combined with 8 sequential ifs: 9 * 256 >> 200
+    public function processWithMatch(int $status, int $a, int $b, int $c, int $d, int $e, int $f, int $g, int $h): string
+    {
+        $label = match ($status) {
+            1 => 'one',
+            2 => 'two',
+            3 => 'three',
+            4 => 'four',
+            5 => 'five',
+            6 => 'six',
+            7 => 'seven',
+            8 => 'eight',
+        };
+
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+
+        if ($f > 0) {
+            echo 'f';
+        }
+
+        if ($g > 0) {
+            echo 'g';
+        }
+
+        if ($h > 0) {
+            echo 'h';
+        }
+
+        return $label;
+    }
+}

--- a/tests/Rules/NpathComplexity/Fixture/MediumNpathClass.php
+++ b/tests/Rules/NpathComplexity/Fixture/MediumNpathClass.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity\Fixture;
+
+class MediumNpathClass
+{
+    // NPath = 2^6 = 64 (six independent if statements — exceeds threshold of 32 but not 200)
+    public function moderateMethod(int $a, int $b, int $c, int $d, int $e, int $f): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+
+        if ($f > 0) {
+            echo 'f';
+        }
+    }
+}

--- a/tests/Rules/NpathComplexity/Fixture/OverflowNpathClass.php
+++ b/tests/Rules/NpathComplexity/Fixture/OverflowNpathClass.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity\Fixture;
+
+class OverflowNpathClass
+{
+    // 63 sequential if statements produce 2^63 > PHP_INT_MAX, triggering the overflow cap
+    public function overflowMethod(int $a): void
+    {
+        if ($a > 1) {
+            echo '1';
+        }
+
+        if ($a > 2) {
+            echo '2';
+        }
+
+        if ($a > 3) {
+            echo '3';
+        }
+
+        if ($a > 4) {
+            echo '4';
+        }
+
+        if ($a > 5) {
+            echo '5';
+        }
+
+        if ($a > 6) {
+            echo '6';
+        }
+
+        if ($a > 7) {
+            echo '7';
+        }
+
+        if ($a > 8) {
+            echo '8';
+        }
+
+        if ($a > 9) {
+            echo '9';
+        }
+
+        if ($a > 10) {
+            echo '10';
+        }
+
+        if ($a > 11) {
+            echo '11';
+        }
+
+        if ($a > 12) {
+            echo '12';
+        }
+
+        if ($a > 13) {
+            echo '13';
+        }
+
+        if ($a > 14) {
+            echo '14';
+        }
+
+        if ($a > 15) {
+            echo '15';
+        }
+
+        if ($a > 16) {
+            echo '16';
+        }
+
+        if ($a > 17) {
+            echo '17';
+        }
+
+        if ($a > 18) {
+            echo '18';
+        }
+
+        if ($a > 19) {
+            echo '19';
+        }
+
+        if ($a > 20) {
+            echo '20';
+        }
+
+        if ($a > 21) {
+            echo '21';
+        }
+
+        if ($a > 22) {
+            echo '22';
+        }
+
+        if ($a > 23) {
+            echo '23';
+        }
+
+        if ($a > 24) {
+            echo '24';
+        }
+
+        if ($a > 25) {
+            echo '25';
+        }
+
+        if ($a > 26) {
+            echo '26';
+        }
+
+        if ($a > 27) {
+            echo '27';
+        }
+
+        if ($a > 28) {
+            echo '28';
+        }
+
+        if ($a > 29) {
+            echo '29';
+        }
+
+        if ($a > 30) {
+            echo '30';
+        }
+
+        if ($a > 31) {
+            echo '31';
+        }
+
+        if ($a > 32) {
+            echo '32';
+        }
+
+        if ($a > 33) {
+            echo '33';
+        }
+
+        if ($a > 34) {
+            echo '34';
+        }
+
+        if ($a > 35) {
+            echo '35';
+        }
+
+        if ($a > 36) {
+            echo '36';
+        }
+
+        if ($a > 37) {
+            echo '37';
+        }
+
+        if ($a > 38) {
+            echo '38';
+        }
+
+        if ($a > 39) {
+            echo '39';
+        }
+
+        if ($a > 40) {
+            echo '40';
+        }
+
+        if ($a > 41) {
+            echo '41';
+        }
+
+        if ($a > 42) {
+            echo '42';
+        }
+
+        if ($a > 43) {
+            echo '43';
+        }
+
+        if ($a > 44) {
+            echo '44';
+        }
+
+        if ($a > 45) {
+            echo '45';
+        }
+
+        if ($a > 46) {
+            echo '46';
+        }
+
+        if ($a > 47) {
+            echo '47';
+        }
+
+        if ($a > 48) {
+            echo '48';
+        }
+
+        if ($a > 49) {
+            echo '49';
+        }
+
+        if ($a > 50) {
+            echo '50';
+        }
+
+        if ($a > 51) {
+            echo '51';
+        }
+
+        if ($a > 52) {
+            echo '52';
+        }
+
+        if ($a > 53) {
+            echo '53';
+        }
+
+        if ($a > 54) {
+            echo '54';
+        }
+
+        if ($a > 55) {
+            echo '55';
+        }
+
+        if ($a > 56) {
+            echo '56';
+        }
+
+        if ($a > 57) {
+            echo '57';
+        }
+
+        if ($a > 58) {
+            echo '58';
+        }
+
+        if ($a > 59) {
+            echo '59';
+        }
+
+        if ($a > 60) {
+            echo '60';
+        }
+
+        if ($a > 61) {
+            echo '61';
+        }
+
+        if ($a > 62) {
+            echo '62';
+        }
+
+        if ($a > 63) {
+            echo '63';
+        }
+    }
+}

--- a/tests/Rules/NpathComplexity/IgnorePatternTest.php
+++ b/tests/Rules/NpathComplexity/IgnorePatternTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity;
+
+use Orrison\MeliorStan\Rules\NpathComplexity\NpathComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<NpathComplexityRule>
+ */
+class IgnorePatternTest extends RuleTestCase
+{
+    public function testMethodMatchingPatternIsSkipped(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/IgnoredMethodClass.php'], []);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignore_pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NpathComplexityRule::class);
+    }
+}

--- a/tests/Rules/NpathComplexity/InvalidPatternTest.php
+++ b/tests/Rules/NpathComplexity/InvalidPatternTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity;
+
+use InvalidArgumentException;
+use Orrison\MeliorStan\Rules\NpathComplexity\NpathComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<NpathComplexityRule>
+ */
+class InvalidPatternTest extends RuleTestCase
+{
+    public function testInvalidPattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid regex pattern in ignore_pattern configuration');
+
+        $this->analyse([
+            __DIR__ . '/Fixture/HighNpathClass.php',
+        ], []);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/invalid_pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NpathComplexityRule::class);
+    }
+}

--- a/tests/Rules/NpathComplexity/OverflowTest.php
+++ b/tests/Rules/NpathComplexity/OverflowTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\NpathComplexity;
+
+use Orrison\MeliorStan\Rules\NpathComplexity\NpathComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<NpathComplexityRule>
+ */
+class OverflowTest extends RuleTestCase
+{
+    public function testMethodWithOverflowingNpathUsesOverflowMessage(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/OverflowNpathClass.php'],
+            [
+                [
+                    sprintf(NpathComplexityRule::ERROR_MESSAGE_OVERFLOW, 'Method', 'overflowMethod', 200),
+                    8,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/default.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NpathComplexityRule::class);
+    }
+}

--- a/tests/Rules/NpathComplexity/config/custom_threshold.neon
+++ b/tests/Rules/NpathComplexity/config/custom_threshold.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\NpathComplexity\NpathComplexityRule
+
+parameters:
+    meliorstan:
+        npath_complexity:
+            maximum: 32

--- a/tests/Rules/NpathComplexity/config/default.neon
+++ b/tests/Rules/NpathComplexity/config/default.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\NpathComplexity\NpathComplexityRule

--- a/tests/Rules/NpathComplexity/config/ignore_pattern.neon
+++ b/tests/Rules/NpathComplexity/config/ignore_pattern.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\NpathComplexity\NpathComplexityRule
+
+parameters:
+    meliorstan:
+        npath_complexity:
+            ignore_pattern: '^calculate'

--- a/tests/Rules/NpathComplexity/config/invalid_pattern.neon
+++ b/tests/Rules/NpathComplexity/config/invalid_pattern.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\NpathComplexity\NpathComplexityRule
+
+parameters:
+    meliorstan:
+        npath_complexity:
+            ignore_pattern: '[invalid'

--- a/tests/Support/NpathComplexityCalculatorTest.php
+++ b/tests/Support/NpathComplexityCalculatorTest.php
@@ -139,6 +139,13 @@ class NpathComplexityCalculatorTest extends TestCase
         $this->assertSame(2, $this->calculator->calculate($method));
     }
 
+    public function testReturnWithTernaryWithAndConditionGivesNpathThree(): void
+    {
+        // condition has 1 && operator → condPaths=1; then=1, else=1 → 1+1+1=3
+        $method = $this->parseMethod('public function foo(int $a, int $b): string { return ($a > 0 && $b > 0) ? "yes" : "no"; }');
+        $this->assertSame(3, $this->calculator->calculate($method));
+    }
+
     public function testReturnWithNullCoalesceGivesNpathTwo(): void
     {
         $method = $this->parseMethod('public function foo(?int $a): int { return $a ?? 0; }');

--- a/tests/Support/NpathComplexityCalculatorTest.php
+++ b/tests/Support/NpathComplexityCalculatorTest.php
@@ -208,6 +208,39 @@ class NpathComplexityCalculatorTest extends TestCase
         $this->assertSame(3, $this->calculator->calculate($nested));
     }
 
+    // ── try-finally ───────────────────────────────────────────────────────────
+
+    public function testTryFinallyWithNoBranchingDoesNotChangePaths(): void
+    {
+        // finally NPath = 1, so multiplying doesn't change the result
+        $method = $this->parseMethod('public function foo(): void { try { echo "ok"; } finally { echo "done"; } }');
+        $this->assertSame(1, $this->calculator->calculate($method));
+    }
+
+    public function testTryFinallyWithBranchingMultipliesNpath(): void
+    {
+        // try NPath = 1, finally NPath = 2 (the if) → 1 * 2 = 2
+        $method = $this->parseMethod('public function foo(int $b): void { try { echo "ok"; } finally { if ($b > 0) { echo "b"; } } }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    public function testTryCatchFinallyWithBranchingMultipliesAllPaths(): void
+    {
+        // try NPath = 1, catch NPath = 1 → additive = 2; finally NPath = 2 (the if) → 2 * 2 = 4
+        $method = $this->parseMethod('public function foo(int $b): void { try { echo "ok"; } catch (\Exception $e) { echo "err"; } finally { if ($b > 0) { echo "b"; } } }');
+        $this->assertSame(4, $this->calculator->calculate($method));
+    }
+
+    // ── overflow guard ────────────────────────────────────────────────────────
+
+    public function testCalculationCapsAtPhpIntMaxToPreventOverflow(): void
+    {
+        // 63 sequential ifs would produce 2^63 > PHP_INT_MAX; the guard returns PHP_INT_MAX instead
+        $ifs = implode(' ', array_fill(0, 63, 'if ($a > 0) { echo "x"; }'));
+        $method = $this->parseMethod("public function foo(int \$a): void { {$ifs} }");
+        $this->assertSame(PHP_INT_MAX, $this->calculator->calculate($method));
+    }
+
     // ── closure / arrow function atomicity ───────────────────────────────────
 
     public function testClosureInsideMethodIsTreatedAsAtomicNpath(): void

--- a/tests/Support/NpathComplexityCalculatorTest.php
+++ b/tests/Support/NpathComplexityCalculatorTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Support;
+
+use Orrison\MeliorStan\Support\NpathComplexityCalculator;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+
+class NpathComplexityCalculatorTest extends TestCase
+{
+    protected NpathComplexityCalculator $calculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = new NpathComplexityCalculator();
+    }
+
+    // ── Base cases ────────────────────────────────────────────────────────────
+
+    public function testEmptyMethodHasNpathOfOne(): void
+    {
+        $method = $this->parseMethod('public function foo(): void {}');
+        $this->assertSame(1, $this->calculator->calculate($method));
+    }
+
+    public function testAbstractMethodHasNpathOfOne(): void
+    {
+        $method = $this->parseMethod('abstract public function foo(): void;');
+        $this->assertSame(1, $this->calculator->calculate($method));
+    }
+
+    public function testSingleSimpleStatementHasNpathOfOne(): void
+    {
+        $method = $this->parseMethod('public function foo(): void { echo "hello"; }');
+        $this->assertSame(1, $this->calculator->calculate($method));
+    }
+
+    // ── if statements ─────────────────────────────────────────────────────────
+
+    public function testSimpleIfWithoutElseGivesNpathTwo(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a): void { if ($a > 0) { echo "y"; } }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    public function testSimpleIfElseGivesNpathTwo(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a): void { if ($a > 0) { echo "y"; } else { echo "n"; } }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    public function testIfElseifNoElseGivesNpathThree(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a): void { if ($a > 0) { echo "pos"; } elseif ($a < 0) { echo "neg"; } }');
+        $this->assertSame(3, $this->calculator->calculate($method));
+    }
+
+    public function testIfElseifElseGivesNpathThree(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a): void { if ($a > 0) { echo "pos"; } elseif ($a < 0) { echo "neg"; } else { echo "zero"; } }');
+        $this->assertSame(3, $this->calculator->calculate($method));
+    }
+
+    public function testIfWithAndConditionAddsOnePath(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a, int $b): void { if ($a > 0 && $b > 0) { echo "both"; } }');
+        $this->assertSame(3, $this->calculator->calculate($method));
+    }
+
+    public function testIfWithOrConditionAddsOnePath(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a, int $b): void { if ($a > 0 || $b > 0) { echo "either"; } }');
+        $this->assertSame(3, $this->calculator->calculate($method));
+    }
+
+    // ── Loop statements ───────────────────────────────────────────────────────
+
+    public function testWhileLoopGivesNpathTwo(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a): void { while ($a > 0) { $a--; } }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    public function testDoWhileLoopGivesNpathTwo(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a): void { do { $a--; } while ($a > 0); }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    public function testForLoopGivesNpathTwo(): void
+    {
+        $method = $this->parseMethod('public function foo(): void { for ($i = 0; $i < 3; $i++) { echo $i; } }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    public function testForeachLoopGivesNpathTwo(): void
+    {
+        $method = $this->parseMethod('public function foo(array $items): void { foreach ($items as $item) { echo $item; } }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    // ── switch ────────────────────────────────────────────────────────────────
+
+    public function testSwitchWithTwoCasesNoDefaultGivesNpathThree(): void
+    {
+        // 2 case stmts + 1 for no-default path
+        $method = $this->parseMethod('public function foo(int $a): void { switch ($a) { case 1: echo "one"; break; case 2: echo "two"; break; } }');
+        $this->assertSame(3, $this->calculator->calculate($method));
+    }
+
+    public function testSwitchWithTwoCasesAndDefaultGivesNpathThree(): void
+    {
+        // 2 cases + 1 default = 3 paths
+        $method = $this->parseMethod('public function foo(int $a): void { switch ($a) { case 1: echo "one"; break; case 2: echo "two"; break; default: echo "other"; } }');
+        $this->assertSame(3, $this->calculator->calculate($method));
+    }
+
+    // ── try-catch ─────────────────────────────────────────────────────────────
+
+    public function testTryCatchGivesNpathTwo(): void
+    {
+        $method = $this->parseMethod('public function foo(): void { try { echo "ok"; } catch (\Exception $e) { echo "err"; } }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    public function testTryWithTwoCatchesGivesNpathThree(): void
+    {
+        $method = $this->parseMethod('public function foo(): void { try { echo "ok"; } catch (\RuntimeException $e) { echo "runtime"; } catch (\Exception $e) { echo "other"; } }');
+        $this->assertSame(3, $this->calculator->calculate($method));
+    }
+
+    // ── return and expression paths ───────────────────────────────────────────
+
+    public function testReturnWithTernaryGivesNpathTwo(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a): string { return $a > 0 ? "yes" : "no"; }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    public function testReturnWithNullCoalesceGivesNpathTwo(): void
+    {
+        $method = $this->parseMethod('public function foo(?int $a): int { return $a ?? 0; }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    public function testAssignmentWithNullCoalesceCountsInExpressionStatement(): void
+    {
+        $method = $this->parseMethod('public function foo(?int $a): void { $b = $a ?? 0; }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    // ── match expression ──────────────────────────────────────────────────────
+
+    public function testMatchWithThreeArmsNoDefaultGivesFourPaths(): void
+    {
+        // 3 arms + 1 for no-default (UnhandledMatchError)
+        $method = $this->parseMethod('public function foo(int $a): string { return match($a) { 1 => "one", 2 => "two", 3 => "three" }; }');
+        $this->assertSame(4, $this->calculator->calculate($method));
+    }
+
+    public function testMatchWithTwoArmsAndDefaultGivesTwoPaths(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a): string { return match($a) { 1 => "one", default => "other" }; }');
+        $this->assertSame(2, $this->calculator->calculate($method));
+    }
+
+    // ── sequential multiplication ─────────────────────────────────────────────
+
+    public function testTwoSequentialIfsMultiply(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a, int $b): void { if ($a > 0) { echo "a"; } if ($b > 0) { echo "b"; } }');
+        $this->assertSame(4, $this->calculator->calculate($method)); // 2 × 2
+    }
+
+    public function testThreeSequentialIfsMultiply(): void
+    {
+        $method = $this->parseMethod('public function foo(int $a, int $b, int $c): void { if ($a > 0) { echo "a"; } if ($b > 0) { echo "b"; } if ($c > 0) { echo "c"; } }');
+        $this->assertSame(8, $this->calculator->calculate($method)); // 2 × 2 × 2
+    }
+
+    public function testEightSequentialIfsGiveNpath256(): void
+    {
+        $code = '
+            public function foo(int $a, int $b, int $c, int $d, int $e, int $f, int $g, int $h): void {
+                if ($a > 0) { echo "a"; }
+                if ($b > 0) { echo "b"; }
+                if ($c > 0) { echo "c"; }
+                if ($d > 0) { echo "d"; }
+                if ($e > 0) { echo "e"; }
+                if ($f > 0) { echo "f"; }
+                if ($g > 0) { echo "g"; }
+                if ($h > 0) { echo "h"; }
+            }
+        ';
+        $method = $this->parseMethod($code);
+        $this->assertSame(256, $this->calculator->calculate($method)); // 2^8
+    }
+
+    // ── nested vs sequential ──────────────────────────────────────────────────
+
+    public function testNestedIfIsAdditiveNotMultiplicative(): void
+    {
+        // Nested: if ($a) { if ($b) {} } → NPath = 0 + (0 + 1 + 1) + 1 = 3
+        // Sequential: if ($a) {}; if ($b) {} → NPath = 2 × 2 = 4
+        $nested = $this->parseMethod('public function foo(int $a, int $b): void { if ($a > 0) { if ($b > 0) { echo "both"; } } }');
+        $this->assertSame(3, $this->calculator->calculate($nested));
+    }
+
+    // ── closure / arrow function atomicity ───────────────────────────────────
+
+    public function testClosureInsideMethodIsTreatedAsAtomicNpath(): void
+    {
+        $method = $this->parseMethod('public function foo(array $items): array { return array_filter($items, function($item) { if ($item > 0) { return true; } return false; }); }');
+        $this->assertSame(1, $this->calculator->calculate($method));
+    }
+
+    public function testArrowFunctionInsideMethodIsTreatedAsAtomicNpath(): void
+    {
+        $method = $this->parseMethod('public function foo(array $items): array { return array_filter($items, fn($item) => $item > 0); }');
+        $this->assertSame(1, $this->calculator->calculate($method));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    protected function parseMethod(string $methodCode): ClassMethod
+    {
+        $parser = (new ParserFactory())->createForHostVersion();
+        $stmts = $parser->parse("<?php class Wrapper { {$methodCode} }");
+        $nodeFinder = new NodeFinder();
+
+        /** @var ClassMethod[] $methods */
+        $methods = $nodeFinder->findInstanceOf($stmts ?? [], ClassMethod::class);
+
+        return $methods[0];
+    }
+}


### PR DESCRIPTION
- Implemented NPath complexity detection for methods and functions.
- Introduced configuration options for maximum complexity threshold and ignore patterns.
- Added NpathComplexityRule class to process nodes and calculate complexity.
- Created NpathComplexityCalculator to compute NPath values based on control structures.
- Developed tests for default options, custom thresholds, ignore patterns, and invalid regex patterns.
- Included fixtures for various complexity scenarios to validate rule behavior.
- Documented NPath complexity in a new markdown file for user reference.

Closes https://github.com/Orrison/MeliorStan/issues/38