### PR TITLE
Add CognitiveComplexity Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ parameters:
 | **[ExcessiveClassComplexity](docs/ExcessiveClassComplexity.md)** | Detects classes with excessive total cyclomatic complexity (Weighted Method Count) | Classes, Interfaces, Traits, Enums |
 | **[ExcessiveParameterList](docs/ExcessiveParameterList.md)** | Detects functions, methods, closures, and arrow functions with too many parameters | Functions, Methods, Closures, Arrow Functions |
 | **[ExcessivePublicCount](docs/ExcessivePublicCount.md)** | Detects classes with an excessive public API surface (public methods + properties) | Classes, Interfaces, Traits, Enums |
-| **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods with high cyclomatic complexity | Methods, Classes |
+| **[CyclomaticComplexity](docs/CyclomaticComplexity.md)** | Detects methods, functions, and classes with high cyclomatic complexity | Methods, Functions, Classes |
 | **[NpathComplexity](docs/NpathComplexity.md)** | Detects methods and functions with high NPath complexity (number of acyclic execution paths) | Methods, Functions |
+| **[CognitiveComplexity](docs/CognitiveComplexity.md)** | Detects methods, functions, and classes with high Cognitive Complexity, the SonarSource understandability metric with a nesting penalty | Methods, Functions, Classes |
 | **[NumberOfChildren](docs/NumberOfChildren.md)** | Detects classes with too many direct child classes | Class Hierarchy |
 | **[StaticAccess](docs/StaticAccess.md)** | Detects static method calls and optionally static property access that create tight coupling | Static Access |
 | **[TooManyFields](docs/TooManyFields.md)** | Detects classes and traits with an excessive number of instance fields | Classes, Traits |

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -141,6 +141,11 @@ parametersSchema:
             maximum: int(),
             ignore_pattern: string(),
         ]),
+        cognitive_complexity: structure([
+            method_maximum: int(),
+            class_maximum: int(),
+            ignore_pattern: string(),
+        ]),
     ])
 
 # default parameters
@@ -255,6 +260,10 @@ parameters:
             ignore_pattern: ''
         npath_complexity:
             maximum: 200
+            ignore_pattern: ''
+        cognitive_complexity:
+            method_maximum: 15
+            class_maximum: 50
             ignore_pattern: ''
 
 services:
@@ -426,6 +435,7 @@ services:
             - %meliorstan.excessive_parameter_list.ignore_pattern%
     - Orrison\MeliorStan\Support\CyclomaticComplexityCalculator
     - Orrison\MeliorStan\Support\NpathComplexityCalculator
+    - Orrison\MeliorStan\Support\CognitiveComplexityCalculator
     -
         factory: Orrison\MeliorStan\Rules\ExcessiveClassComplexity\Config
         arguments:
@@ -436,3 +446,9 @@ services:
         arguments:
             - %meliorstan.npath_complexity.maximum%
             - %meliorstan.npath_complexity.ignore_pattern%
+    -
+        factory: Orrison\MeliorStan\Rules\CognitiveComplexity\Config
+        arguments:
+            - %meliorstan.cognitive_complexity.method_maximum%
+            - %meliorstan.cognitive_complexity.class_maximum%
+            - %meliorstan.cognitive_complexity.ignore_pattern%

--- a/docs/CognitiveComplexity.md
+++ b/docs/CognitiveComplexity.md
@@ -1,0 +1,167 @@
+# CognitiveComplexity
+
+This rule detects methods with high Cognitive Complexity, a metric that measures how difficult code is to **understand** rather than how difficult it is to test (cyclomatic) or how many paths it has (NPath).
+
+Cognitive Complexity is the SonarSource metric defined by G. Ann Campbell in the 2017 paper *"Cognitive Complexity — A new way of measuring understandability"*. Its headline feature is a **nesting penalty**: a flat sequence of five `if` statements scores far less than five `if` statements nested five levels deep, even though both have identical cyclomatic complexity.
+
+The rule reports both per-method scores and the per-class total (sum of all method scores).
+
+## Configuration
+
+This rule supports the following configuration options:
+
+### `method_maximum`
+- **Type**: `int`
+- **Default**: `15`
+- **Description**: Per-method threshold. Any method with a Cognitive Complexity above this value triggers an error. The default of 15 matches the SonarSource industry recommendation.
+
+### `class_maximum`
+- **Type**: `int`
+- **Default**: `50`
+- **Description**: Per-class threshold. The sum of every method's Cognitive Complexity must not exceed this value. Unlike Cyclomatic Complexity which averages, Cognitive Complexity sums — a class with 50 trivial getters scores ~0, while a class with one tangled method scores high.
+
+### `ignore_pattern`
+- **Type**: `string`
+- **Default**: `''`
+- **Description**: A regex pattern matched against the method **name** (case-insensitive). Matching methods are skipped — they are neither reported individually nor included in the class total. Example: `^(setUp|tearDown|boot)` skips common lifecycle methods.
+
+## Usage
+
+Add the rule to your PHPStan configuration:
+
+```neon
+includes:
+    - vendor/orrison/meliorstan/config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule
+
+parameters:
+    meliorstan:
+        cognitive_complexity:
+            method_maximum: 15
+            class_maximum: 50
+            ignore_pattern: ''
+```
+
+## Examples
+
+### Default Configuration
+
+```php
+<?php
+
+class OrderService
+{
+    // ✓ Valid - score 5 (five sequential ifs, no nesting penalty)
+    public function validateFields(Order $order): bool
+    {
+        if ($order->customerId === null) { return false; }
+        if ($order->amount <= 0) { return false; }
+        if ($order->currency === '') { return false; }
+        if ($order->items === []) { return false; }
+        if ($order->shippingAddress === null) { return false; }
+
+        return true;
+    }
+
+    // ✗ Error: method process() has a Cognitive Complexity of 21. The allowed threshold is 15.
+    // Six-deep nesting: 1 + 2 + 3 + 4 + 5 + 6 = 21
+    public function process(Order $order): void
+    {
+        if ($order->isPaid()) {            // +1 (nesting=0)
+            if ($order->isShippable()) {   // +2 (nesting=1)
+                foreach ($order->items as $item) {     // +3 (nesting=2)
+                    if ($item->inStock()) {            // +4 (nesting=3)
+                        while ($item->reserve()) {     // +5 (nesting=4)
+                            if ($item->shippable()) {  // +6 (nesting=5)
+                                $this->ship($item);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+### Configuration Examples
+
+#### Custom Method Threshold
+
+```neon
+parameters:
+    meliorstan:
+        cognitive_complexity:
+            method_maximum: 5
+```
+
+```php
+// ✗ Error: method process() has a Cognitive Complexity of 15. The allowed threshold is 5.
+public function process(int $a, int $b, int $c, int $d, int $e): void
+{
+    if ($a > 0) {
+        if ($b > 0) {
+            if ($c > 0) {
+                if ($d > 0) {
+                    if ($e > 0) {
+                        echo 'all';
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+#### Custom Class Threshold
+
+```neon
+parameters:
+    meliorstan:
+        cognitive_complexity:
+            class_maximum: 30
+```
+
+```php
+// ✗ Error: class "WideClass" has a total Cognitive Complexity of 55. The allowed threshold is 30.
+class WideClass
+{
+    // 11 methods, each scoring 5 (five sequential ifs).
+    // No single method exceeds method_maximum, but the sum exceeds class_maximum.
+}
+```
+
+#### Ignore Pattern
+
+```neon
+parameters:
+    meliorstan:
+        cognitive_complexity:
+            ignore_pattern: '^(setUp|tearDown|boot|handle)'
+```
+
+```php
+// ✓ Now valid — name matches ignore_pattern
+public function handle(Request $request, Closure $next): Response
+{
+    // Complex middleware logic with many checks
+}
+```
+
+## Important Notes
+
+- The rule applies to class methods and standalone functions. Closures and arrow functions are not analyzed as their own units (their bodies still contribute to the enclosing method/function score, with a +1 nesting penalty for the closure boundary).
+- Class methods are reported individually (against `method_maximum`) and aggregated for the per-class total (against `class_maximum`). Standalone functions are reported individually only — there is no class to aggregate into.
+- **Structural increments** (cost: `1 + currentNesting`): `if`, `else if`, ternary, `for`, `foreach`, `while`, `do-while`, `switch`, `match`, and `catch`. Entering one of these structures increments the nesting level for whatever lives inside.
+- **Hybrid increments** (cost: `1`, no nesting bump): `else`.
+- **Fundamental increments** (cost: `1` flat):
+  - Each *run* of like binary boolean operators in a condition. `a && b && c` adds **+1** (one run); `a && b || c` adds **+2** (two runs); `a && b || c && d` adds **+3**.
+  - `goto`, labeled `break`/`continue`, and multi-level `break N` / `continue N` (where N ≥ 2).
+  - Direct recursion: a method calling itself (`$this->foo()`, `self::foo()`, `static::foo()`, or — for plain functions — `foo()`) adds **+1** (counted once per method, regardless of how many self-calls are made).
+- **Nesting-only** (cost: `0`, but nesting is incremented): `Closure` and `ArrowFunction`. Any control flow inside them is scored at `nesting + 1`.
+- **Ignored entirely** (cost: `0`, no nesting bump): null-coalescing operator (`??`), nullsafe (`?->`), null-coalescing assignment (`??=`), and `try`/`finally` block bodies (catches still cost their structural increment).
+- **Class total is a sum, not an average.** A class of 20 trivial getters scores ~0; a class with one extremely tangled method scores high. This makes the class threshold meaningful in a way cyclomatic averaging cannot.
+- The `ignore_pattern` matches against the method name, not the class name. Ignored methods are excluded from the class total.
+- Cognitive Complexity differs from `CyclomaticComplexity` (decision count) and `NpathComplexity` (path count). All three are complementary: cyclomatic measures testability, NPath measures coverage, cognitive measures understandability.

--- a/docs/CognitiveComplexity.md
+++ b/docs/CognitiveComplexity.md
@@ -161,7 +161,8 @@ public function handle(Request $request, Closure $next): Response
   - `goto` and multi-level `break N` / `continue N` (where N ≥ 2).
   - Direct recursion: a method calling itself (`$this->foo()`, `self::foo()`, `static::foo()`, or — for plain functions — `foo()`) adds **+1** (counted once per method, regardless of how many self-calls are made).
 - **Nesting-only** (cost: `0`, but nesting is incremented): `Closure` and `ArrowFunction`. Any control flow inside them is scored at `nesting + 1`.
-- **Ignored entirely** (cost: `0`, no nesting bump): null-coalescing operator (`??`), nullsafe (`?->`), null-coalescing assignment (`??=`), and `try`/`finally` block bodies (catches still cost their structural increment).
+- **Ignored entirely** (cost: `0`, no nesting bump): null-coalescing operator (`??`), nullsafe (`?->`), and null-coalescing assignment (`??=`).
+- **`try`/`finally`**: the `try` and `finally` keywords themselves add no direct increment and do not increase nesting, but control flow inside their bodies is still scored normally. `catch` blocks still cost their structural increment.
 - **Class total is a sum, not an average.** A class of 20 trivial getters scores ~0; a class with one extremely tangled method scores high. This makes the class threshold meaningful in a way cyclomatic averaging cannot.
 - The `ignore_pattern` matches against the method name, not the class name. Ignored methods are excluded from the class total.
 

--- a/docs/CognitiveComplexity.md
+++ b/docs/CognitiveComplexity.md
@@ -154,11 +154,11 @@ public function handle(Request $request, Closure $next): Response
 
 - The rule applies to class methods and standalone functions. Closures and arrow functions are not analyzed as their own units (their bodies still contribute to the enclosing method/function score, with a +1 nesting penalty for the closure boundary).
 - Class methods are reported individually (against `method_maximum`) and aggregated for the per-class total (against `class_maximum`). Standalone functions are reported individually only — there is no class to aggregate into.
-- **Structural increments** (cost: `1 + currentNesting`): `if`, `else if`, ternary, `for`, `foreach`, `while`, `do-while`, `switch`, `match`, and `catch`. Entering one of these structures increments the nesting level for whatever lives inside.
-- **Hybrid increments** (cost: `1`, no nesting bump): `else`.
+- **Structural increments** (cost: `1 + currentNesting`): `if`, ternary, `for`, `foreach`, `while`, `do-while`, `switch`, `match`, and `catch`. Entering one of these structures increments the nesting level for whatever lives inside.
+- **Hybrid increments** (cost: `1`, no nesting bump): `else` and `else if`.
 - **Fundamental increments** (cost: `1` flat):
   - Each *run* of like binary boolean operators in a condition. `a && b && c` adds **+1** (one run); `a && b || c` adds **+2** (two runs); `a && b || c && d` adds **+3**.
-  - `goto`, labeled `break`/`continue`, and multi-level `break N` / `continue N` (where N ≥ 2).
+  - `goto` and multi-level `break N` / `continue N` (where N ≥ 2).
   - Direct recursion: a method calling itself (`$this->foo()`, `self::foo()`, `static::foo()`, or — for plain functions — `foo()`) adds **+1** (counted once per method, regardless of how many self-calls are made).
 - **Nesting-only** (cost: `0`, but nesting is incremented): `Closure` and `ArrowFunction`. Any control flow inside them is scored at `nesting + 1`.
 - **Ignored entirely** (cost: `0`, no nesting bump): null-coalescing operator (`??`), nullsafe (`?->`), null-coalescing assignment (`??=`), and `try`/`finally` block bodies (catches still cost their structural increment).

--- a/docs/CognitiveComplexity.md
+++ b/docs/CognitiveComplexity.md
@@ -157,7 +157,7 @@ public function handle(Request $request, Closure $next): Response
 - **Structural increments** (cost: `1 + currentNesting`): `if`, ternary, `for`, `foreach`, `while`, `do-while`, `switch`, `match`, and `catch`. Entering one of these structures increments the nesting level for whatever lives inside.
 - **Hybrid increments** (cost: `1`, no nesting bump): `else` and `else if`.
 - **Fundamental increments** (cost: `1` flat):
-  - Each *run* of like binary boolean operators in a condition. `a && b && c` adds **+1** (one run); `a && b || c` adds **+2** (two runs); `a && b || c && d` adds **+3**.
+  - Each *run* of like binary boolean operators, wherever it appears (conditions, assignments, returns, etc.). `a && b && c` adds **+1** (one run); `a && b || c` adds **+2** (two runs); `a && b || c && d` adds **+3**.
   - `goto` and multi-level `break N` / `continue N` (where N ≥ 2).
   - Direct recursion: a method calling itself (`$this->foo()`, `self::foo()`, `static::foo()`, or — for plain functions — `foo()`) adds **+1** (counted once per method, regardless of how many self-calls are made).
 - **Nesting-only** (cost: `0`, but nesting is incremented): `Closure` and `ArrowFunction`. Any control flow inside them is scored at `nesting + 1`.

--- a/docs/CognitiveComplexity.md
+++ b/docs/CognitiveComplexity.md
@@ -164,4 +164,18 @@ public function handle(Request $request, Closure $next): Response
 - **Ignored entirely** (cost: `0`, no nesting bump): null-coalescing operator (`??`), nullsafe (`?->`), null-coalescing assignment (`??=`), and `try`/`finally` block bodies (catches still cost their structural increment).
 - **Class total is a sum, not an average.** A class of 20 trivial getters scores ~0; a class with one extremely tangled method scores high. This makes the class threshold meaningful in a way cyclomatic averaging cannot.
 - The `ignore_pattern` matches against the method name, not the class name. Ignored methods are excluded from the class total.
-- Cognitive Complexity differs from `CyclomaticComplexity` (decision count) and `NpathComplexity` (path count). All three are complementary: cyclomatic measures testability, NPath measures coverage, cognitive measures understandability.
+
+## Related Rules
+
+This suite has three overlapping class-level complexity checks. They are intentionally complementary — each catches a failure mode the others miss. Use whichever signals you actually care about:
+
+| Rule | Class-level metric | Catches | Misses |
+|---|---|---|---|
+| `CognitiveComplexity` (`class_maximum`) | **Sum** of cognitive | Classes that are *hard to understand* — deep nesting, tangled control flow | Wide-but-simple classes (50 trivial getters score ~0) |
+| [`ExcessiveClassComplexity`](ExcessiveClassComplexity.md) | **Sum** of cyclomatic (Weighted Method Count) | God classes — many methods, or a few very complex ones, or both | Cannot tell breadth from depth |
+| [`CyclomaticComplexity`](CyclomaticComplexity.md) (`show_classes_complexity`) | **Average** cyclomatic per method | Classes where every method is dense on average | One bad method drowned by trivial getters (the average dilutes) |
+
+Cognitive vs cyclomatic at the per-method level is also worth noting:
+- **`CyclomaticComplexity`** (decision count) — measures *testability* (how many paths a test suite must exercise).
+- **[`NpathComplexity`](NpathComplexity.md)** (path product) — measures *coverage cost* (number of acyclic paths grows multiplicatively).
+- **`CognitiveComplexity`** (this rule) — measures *understandability* (how hard the code is for a human to follow), with a nesting penalty the others lack.

--- a/docs/CyclomaticComplexity.md
+++ b/docs/CyclomaticComplexity.md
@@ -189,3 +189,15 @@ class HighAverageComplexity
 - Ternary expressions (`?:`) count as a decision point
 - Class average is calculated as: total complexity of all methods / number of methods
 - Consider refactoring high-complexity methods by extracting smaller, focused methods
+
+## Related Rules
+
+This suite has three overlapping class-level complexity checks. They are intentionally complementary — each catches a failure mode the others miss. Use whichever signals you actually care about:
+
+| Rule | Class-level metric | Catches | Misses |
+|---|---|---|---|
+| `CyclomaticComplexity` (`show_classes_complexity`) | **Average** cyclomatic per method | Classes where every method is dense on average | One bad method drowned by trivial getters (the average dilutes) |
+| [`ExcessiveClassComplexity`](ExcessiveClassComplexity.md) | **Sum** of cyclomatic (Weighted Method Count) | God classes — many methods, or a few very complex ones, or both | Cannot tell breadth from depth |
+| [`CognitiveComplexity`](CognitiveComplexity.md) (`class_maximum`) | **Sum** of cognitive | Classes that are *hard to understand* — deep nesting, tangled control flow | Wide-but-simple classes (50 trivial getters score ~0) |
+
+The average in this rule (`show_classes_complexity`) is the weakest of the three signals because trivial methods dilute it. If you only want one class-level cyclomatic check, prefer `ExcessiveClassComplexity`. The average still has a niche — flagging classes where the *typical* method is dense rather than the *total* — which is why both exist (this rule mirrors PHPMD's `CyclomaticComplexity`, while `ExcessiveClassComplexity` mirrors PHPMD's `ExcessiveClassComplexity`).

--- a/docs/CyclomaticComplexity.md
+++ b/docs/CyclomaticComplexity.md
@@ -17,17 +17,17 @@ This rule supports the following configuration options:
 ### `report_level`
 - **Type**: `int`
 - **Default**: `10`
-- **Description**: The cyclomatic complexity threshold. Methods with complexity exceeding this value will trigger an error.
+- **Description**: The cyclomatic complexity threshold. Methods and standalone functions with complexity exceeding this value will trigger an error.
 
 ### `show_classes_complexity`
 - **Type**: `bool`
 - **Default**: `true`
-- **Description**: When enabled, reports an error if the average complexity of all methods in a class exceeds the threshold.
+- **Description**: When enabled, reports an error if the average complexity of all methods in a class exceeds the threshold. (Standalone functions are unaffected by this option since they have no class to aggregate into.)
 
 ### `show_methods_complexity`
 - **Type**: `bool`
 - **Default**: `true`
-- **Description**: When enabled, reports an error for individual methods that exceed the complexity threshold.
+- **Description**: When enabled, reports an error for individual methods and standalone functions that exceed the complexity threshold.
 
 ## Usage
 
@@ -182,7 +182,7 @@ class HighAverageComplexity
 
 ## Important Notes
 
-- The rule applies to classes, interfaces, traits, and enums
+- The rule applies to classes, interfaces, traits, enums, and standalone functions. Standalone functions are reported individually (subject to `show_methods_complexity`) but never aggregated.
 - Each `case` in a switch statement adds 1 to complexity (except `default`)
 - Both short-circuit operators (`&&`, `||`) and textual operators (`and`, `or`) are counted
 - The null coalesce operator (`??`) counts as a decision point

--- a/docs/ExcessiveClassComplexity.md
+++ b/docs/ExcessiveClassComplexity.md
@@ -154,3 +154,15 @@ class LegacyServiceFacade
 - The threshold applies to the **total** complexity across all methods, not the average — see `CyclomaticComplexity` for average-based checking
 - Consider splitting high-WMC classes into focused, single-responsibility classes
 - The `ignore_pattern` is matched case-insensitively against the class name only, not the full namespace
+
+## Related Rules
+
+This suite has three overlapping class-level complexity checks. They are intentionally complementary — each catches a failure mode the others miss. Use whichever signals you actually care about:
+
+| Rule | Class-level metric | Catches | Misses |
+|---|---|---|---|
+| `ExcessiveClassComplexity` | **Sum** of cyclomatic (Weighted Method Count) | God classes — many methods, or a few very complex ones, or both | Cannot tell breadth from depth |
+| [`CyclomaticComplexity`](CyclomaticComplexity.md) (`show_classes_complexity`) | **Average** cyclomatic per method | Classes where every method is dense on average | One bad method drowned by trivial getters (the average dilutes) |
+| [`CognitiveComplexity`](CognitiveComplexity.md) (`class_maximum`) | **Sum** of cognitive | Classes that are *hard to understand* — deep nesting, tangled control flow | Wide-but-simple classes (50 trivial getters score ~0) |
+
+WMC is the most informative cyclomatic-based class signal — averages dilute under trivial methods. Pair it with `CognitiveComplexity` to also catch classes that are tangled rather than just large.

--- a/src/Rules/CognitiveComplexity/CognitiveComplexityRule.php
+++ b/src/Rules/CognitiveComplexity/CognitiveComplexityRule.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Orrison\MeliorStan\Rules\CyclomaticComplexity;
+namespace Orrison\MeliorStan\Rules\CognitiveComplexity;
 
-use Orrison\MeliorStan\Support\CyclomaticComplexityCalculator;
+use InvalidArgumentException;
+use Orrison\MeliorStan\Support\CognitiveComplexityCalculator;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
@@ -20,15 +21,15 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<Stmt>
  */
-class CyclomaticComplexityRule implements Rule
+class CognitiveComplexityRule implements Rule
 {
-    public const string ERROR_MESSAGE_TEMPLATE_METHOD = 'The %s %s() has a Cyclomatic Complexity of %d. The allowed threshold is %d.';
+    public const string ERROR_MESSAGE_TEMPLATE_METHOD = 'The %s %s() has a Cognitive Complexity of %d. The allowed threshold is %d.';
 
-    public const string ERROR_MESSAGE_TEMPLATE_CLASS = 'The %s "%s" has an average Cyclomatic Complexity of %.2f. The allowed threshold is %d.';
+    public const string ERROR_MESSAGE_TEMPLATE_CLASS = 'The %s "%s" has a total Cognitive Complexity of %d. The allowed threshold is %d.';
 
     public function __construct(
         protected Config $config,
-        protected CyclomaticComplexityCalculator $calculator,
+        protected CognitiveComplexityCalculator $calculator,
     ) {}
 
     /**
@@ -62,13 +63,15 @@ class CyclomaticComplexityRule implements Rule
      */
     protected function processFunction(Function_ $node): array
     {
-        if (! $this->config->getShowMethodsComplexity()) {
+        $name = $node->name->toString();
+
+        if ($this->shouldIgnoreByPattern($name)) {
             return [];
         }
 
         $complexity = $this->calculator->calculate($node);
 
-        if ($complexity <= $this->config->getReportLevel()) {
+        if ($complexity <= $this->config->getMethodMaximum()) {
             return [];
         }
 
@@ -77,12 +80,12 @@ class CyclomaticComplexityRule implements Rule
                 sprintf(
                     self::ERROR_MESSAGE_TEMPLATE_METHOD,
                     'function',
-                    $node->name->toString(),
+                    $name,
                     $complexity,
-                    $this->config->getReportLevel()
+                    $this->config->getMethodMaximum()
                 )
             )
-                ->identifier('MeliorStan.cyclomaticComplexity.method')
+                ->identifier('MeliorStan.cognitiveComplexity.method')
                 ->build(),
         ];
     }
@@ -106,45 +109,70 @@ class CyclomaticComplexityRule implements Rule
         $totalComplexity = 0;
 
         foreach ($methods as $method) {
+            $methodName = $method->name->toString();
+
+            if ($this->shouldIgnoreByPattern($methodName)) {
+                continue;
+            }
+
             $complexity = $this->calculator->calculate($method);
             $totalComplexity += $complexity;
 
-            if ($this->config->getShowMethodsComplexity() && $complexity > $this->config->getReportLevel()) {
+            if ($complexity > $this->config->getMethodMaximum()) {
                 $errors[] = RuleErrorBuilder::message(
                     sprintf(
                         self::ERROR_MESSAGE_TEMPLATE_METHOD,
                         'method',
-                        $method->name->toString(),
+                        $methodName,
                         $complexity,
-                        $this->config->getReportLevel()
+                        $this->config->getMethodMaximum()
                     )
                 )
-                    ->identifier('MeliorStan.cyclomaticComplexity.method')
+                    ->identifier('MeliorStan.cognitiveComplexity.method')
                     ->line($method->getStartLine())
                     ->build();
             }
         }
 
-        if ($this->config->getShowClassesComplexity()) {
-            $averageComplexity = $totalComplexity / count($methods);
-
-            if ($averageComplexity > $this->config->getReportLevel()) {
-                $nodeType = $this->getNodeTypeName($node);
-                $errors[] = RuleErrorBuilder::message(
-                    sprintf(
-                        self::ERROR_MESSAGE_TEMPLATE_CLASS,
-                        $nodeType,
-                        $node->name->toString(),
-                        $averageComplexity,
-                        $this->config->getReportLevel()
-                    )
+        if ($totalComplexity > $this->config->getClassMaximum()) {
+            $nodeType = $this->getNodeTypeName($node);
+            $errors[] = RuleErrorBuilder::message(
+                sprintf(
+                    self::ERROR_MESSAGE_TEMPLATE_CLASS,
+                    $nodeType,
+                    $node->name->toString(),
+                    $totalComplexity,
+                    $this->config->getClassMaximum()
                 )
-                    ->identifier('MeliorStan.cyclomaticComplexity.class')
-                    ->build();
-            }
+            )
+                ->identifier('MeliorStan.cognitiveComplexity.class')
+                ->build();
         }
 
         return $errors;
+    }
+
+    protected function shouldIgnoreByPattern(string $name): bool
+    {
+        $pattern = $this->config->getIgnorePattern();
+
+        if ($pattern === '') {
+            return false;
+        }
+
+        $regex = '/' . $pattern . '/i';
+
+        $result = @preg_match($regex, $name);
+
+        if ($result === false || preg_last_error() !== PREG_NO_ERROR) {
+            $error = preg_last_error_msg();
+
+            throw new InvalidArgumentException(
+                sprintf('Invalid regex pattern in ignore_pattern configuration: "%s". Error: %s', $pattern, $error)
+            );
+        }
+
+        return $result === 1;
     }
 
     protected function getNodeTypeName(ClassLike $node): string

--- a/src/Rules/CognitiveComplexity/Config.php
+++ b/src/Rules/CognitiveComplexity/Config.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Orrison\MeliorStan\Rules\CognitiveComplexity;
+
+class Config
+{
+    public function __construct(
+        protected int $methodMaximum = 15,
+        protected int $classMaximum = 50,
+        protected string $ignorePattern = '',
+    ) {}
+
+    public function getMethodMaximum(): int
+    {
+        return $this->methodMaximum;
+    }
+
+    public function getClassMaximum(): int
+    {
+        return $this->classMaximum;
+    }
+
+    public function getIgnorePattern(): string
+    {
+        return $this->ignorePattern;
+    }
+}

--- a/src/Rules/CyclomaticComplexity/CyclomaticComplexityRule.php
+++ b/src/Rules/CyclomaticComplexity/CyclomaticComplexityRule.php
@@ -51,6 +51,10 @@ class CyclomaticComplexityRule implements Rule
         }
 
         if ($node instanceof ClassLike) {
+            if (! $this->config->getShowMethodsComplexity() && ! $this->config->getShowClassesComplexity()) {
+                return [];
+            }
+
             return $this->processClassLike($node);
         }
 

--- a/src/Support/CognitiveComplexityCalculator.php
+++ b/src/Support/CognitiveComplexityCalculator.php
@@ -338,7 +338,7 @@ class CognitiveComplexityCalculator
             return $node->num->value >= 2;
         }
 
-        return true;
+        return false;
     }
 
     protected function hasDirectRecursion(FunctionLike $node, string $name, bool $isMethod): bool

--- a/src/Support/CognitiveComplexityCalculator.php
+++ b/src/Support/CognitiveComplexityCalculator.php
@@ -1,0 +1,381 @@
+<?php
+
+namespace Orrison\MeliorStan\Support;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use PhpParser\Node\Expr\BinaryOp\LogicalAnd;
+use PhpParser\Node\Expr\BinaryOp\LogicalOr;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Match_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Stmt\Break_;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Continue_;
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Goto_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Switch_;
+use PhpParser\Node\Stmt\TryCatch;
+use PhpParser\Node\Stmt\While_;
+use PhpParser\NodeFinder;
+
+class CognitiveComplexityCalculator
+{
+    public const string BOOL_KIND_AND = 'AND';
+
+    public const string BOOL_KIND_OR = 'OR';
+
+    public function calculate(FunctionLike $node): int
+    {
+        $score = 0;
+
+        foreach ($node->getStmts() ?? [] as $stmt) {
+            $score += $this->scoreNode($stmt, 0, null);
+        }
+
+        $name = $this->getEnclosingName($node);
+
+        if ($name !== null && $this->hasDirectRecursion($node, $name, $node instanceof ClassMethod)) {
+            $score += 1;
+        }
+
+        return $score;
+    }
+
+    protected function getEnclosingName(FunctionLike $node): ?string
+    {
+        if ($node instanceof ClassMethod || $node instanceof Function_) {
+            return $node->name->toString();
+        }
+
+        return null;
+    }
+
+    protected function scoreNode(Node $node, int $nesting, ?string $parentBoolKind): int
+    {
+        if ($node instanceof If_) {
+            return $this->scoreIf($node, $nesting);
+        }
+
+        if ($node instanceof For_) {
+            return $this->scoreFor($node, $nesting);
+        }
+
+        if ($node instanceof Foreach_) {
+            return $this->scoreForeach($node, $nesting);
+        }
+
+        if ($node instanceof While_ || $node instanceof Do_) {
+            return $this->scoreWhileOrDo($node->cond, $node->stmts, $nesting);
+        }
+
+        if ($node instanceof Switch_) {
+            return $this->scoreSwitch($node, $nesting);
+        }
+
+        if ($node instanceof TryCatch) {
+            return $this->scoreTryCatch($node, $nesting);
+        }
+
+        if ($node instanceof Match_) {
+            return $this->scoreMatch($node, $nesting);
+        }
+
+        if ($node instanceof Ternary) {
+            return $this->scoreTernary($node, $nesting);
+        }
+
+        if ($node instanceof Closure || $node instanceof ArrowFunction) {
+            return $this->scoreClosure($node, $nesting);
+        }
+
+        if ($node instanceof Goto_) {
+            return 1;
+        }
+
+        if ($node instanceof Break_ || $node instanceof Continue_) {
+            return $this->isMultiLevelJump($node) ? 1 : 0;
+        }
+
+        $thisKind = $this->getBoolKind($node);
+        $score = 0;
+
+        if ($thisKind !== null && $thisKind !== $parentBoolKind) {
+            $score += 1;
+        }
+
+        $childKind = $thisKind;
+
+        foreach ($node->getSubNodeNames() as $subNodeName) {
+            $subNode = $node->{$subNodeName};
+
+            if ($subNode instanceof Node) {
+                $score += $this->scoreNode($subNode, $nesting, $childKind);
+            } elseif (is_array($subNode)) {
+                foreach ($subNode as $item) {
+                    if ($item instanceof Node) {
+                        $score += $this->scoreNode($item, $nesting, $childKind);
+                    }
+                }
+            }
+        }
+
+        return $score;
+    }
+
+    protected function getBoolKind(Node $node): ?string
+    {
+        if ($node instanceof BooleanAnd || $node instanceof LogicalAnd) {
+            return self::BOOL_KIND_AND;
+        }
+
+        if ($node instanceof BooleanOr || $node instanceof LogicalOr) {
+            return self::BOOL_KIND_OR;
+        }
+
+        return null;
+    }
+
+    protected function scoreIf(If_ $node, int $nesting): int
+    {
+        $score = 1 + $nesting;
+        $score += $this->scoreNode($node->cond, $nesting, null);
+
+        foreach ($node->stmts as $stmt) {
+            $score += $this->scoreNode($stmt, $nesting + 1, null);
+        }
+
+        foreach ($node->elseifs as $elseif) {
+            $score += 1;
+            $score += $this->scoreNode($elseif->cond, $nesting, null);
+
+            foreach ($elseif->stmts as $stmt) {
+                $score += $this->scoreNode($stmt, $nesting + 1, null);
+            }
+        }
+
+        if ($node->else !== null) {
+            $score += 1;
+
+            foreach ($node->else->stmts as $stmt) {
+                $score += $this->scoreNode($stmt, $nesting + 1, null);
+            }
+        }
+
+        return $score;
+    }
+
+    protected function scoreFor(For_ $node, int $nesting): int
+    {
+        $score = 1 + $nesting;
+
+        foreach ($node->init as $expr) {
+            $score += $this->scoreNode($expr, $nesting, null);
+        }
+
+        foreach ($node->cond as $expr) {
+            $score += $this->scoreNode($expr, $nesting, null);
+        }
+
+        foreach ($node->loop as $expr) {
+            $score += $this->scoreNode($expr, $nesting, null);
+        }
+
+        foreach ($node->stmts as $stmt) {
+            $score += $this->scoreNode($stmt, $nesting + 1, null);
+        }
+
+        return $score;
+    }
+
+    protected function scoreForeach(Foreach_ $node, int $nesting): int
+    {
+        $score = 1 + $nesting;
+        $score += $this->scoreNode($node->expr, $nesting, null);
+
+        foreach ($node->stmts as $stmt) {
+            $score += $this->scoreNode($stmt, $nesting + 1, null);
+        }
+
+        return $score;
+    }
+
+    /**
+     * @param Node\Stmt[] $stmts
+     */
+    protected function scoreWhileOrDo(Expr $cond, array $stmts, int $nesting): int
+    {
+        $score = 1 + $nesting;
+        $score += $this->scoreNode($cond, $nesting, null);
+
+        foreach ($stmts as $stmt) {
+            $score += $this->scoreNode($stmt, $nesting + 1, null);
+        }
+
+        return $score;
+    }
+
+    protected function scoreSwitch(Switch_ $node, int $nesting): int
+    {
+        $score = 1 + $nesting;
+        $score += $this->scoreNode($node->cond, $nesting, null);
+
+        foreach ($node->cases as $case) {
+            if ($case->cond !== null) {
+                $score += $this->scoreNode($case->cond, $nesting + 1, null);
+            }
+
+            foreach ($case->stmts as $stmt) {
+                $score += $this->scoreNode($stmt, $nesting + 1, null);
+            }
+        }
+
+        return $score;
+    }
+
+    protected function scoreTryCatch(TryCatch $node, int $nesting): int
+    {
+        $score = 0;
+
+        foreach ($node->stmts as $stmt) {
+            $score += $this->scoreNode($stmt, $nesting, null);
+        }
+
+        foreach ($node->catches as $catch) {
+            $score += $this->scoreCatch($catch, $nesting);
+        }
+
+        if ($node->finally !== null) {
+            foreach ($node->finally->stmts as $stmt) {
+                $score += $this->scoreNode($stmt, $nesting, null);
+            }
+        }
+
+        return $score;
+    }
+
+    protected function scoreCatch(Catch_ $node, int $nesting): int
+    {
+        $score = 1 + $nesting;
+
+        foreach ($node->stmts as $stmt) {
+            $score += $this->scoreNode($stmt, $nesting + 1, null);
+        }
+
+        return $score;
+    }
+
+    protected function scoreMatch(Match_ $node, int $nesting): int
+    {
+        $score = 1 + $nesting;
+        $score += $this->scoreNode($node->cond, $nesting, null);
+
+        foreach ($node->arms as $arm) {
+            if ($arm->conds !== null) {
+                foreach ($arm->conds as $cond) {
+                    $score += $this->scoreNode($cond, $nesting + 1, null);
+                }
+            }
+
+            $score += $this->scoreNode($arm->body, $nesting + 1, null);
+        }
+
+        return $score;
+    }
+
+    protected function scoreTernary(Ternary $node, int $nesting): int
+    {
+        $score = 1 + $nesting;
+        $score += $this->scoreNode($node->cond, $nesting, null);
+
+        if ($node->if !== null) {
+            $score += $this->scoreNode($node->if, $nesting + 1, null);
+        }
+
+        $score += $this->scoreNode($node->else, $nesting + 1, null);
+
+        return $score;
+    }
+
+    protected function scoreClosure(Closure|ArrowFunction $node, int $nesting): int
+    {
+        if ($node instanceof ArrowFunction) {
+            return $this->scoreNode($node->expr, $nesting + 1, null);
+        }
+
+        $score = 0;
+
+        foreach ($node->stmts as $stmt) {
+            $score += $this->scoreNode($stmt, $nesting + 1, null);
+        }
+
+        return $score;
+    }
+
+    protected function isMultiLevelJump(Break_|Continue_ $node): bool
+    {
+        if ($node->num === null) {
+            return false;
+        }
+
+        if ($node->num instanceof Int_) {
+            return $node->num->value >= 2;
+        }
+
+        return true;
+    }
+
+    protected function hasDirectRecursion(FunctionLike $node, string $name, bool $isMethod): bool
+    {
+        $finder = new NodeFinder();
+
+        $found = $finder->findFirst(
+            $node->getStmts() ?? [],
+            function (Node $n) use ($name, $isMethod): bool {
+                if ($isMethod) {
+                    if ($n instanceof MethodCall
+                        && $n->var instanceof Variable
+                        && $n->var->name === 'this'
+                        && $n->name instanceof Identifier
+                        && $n->name->toString() === $name
+                    ) {
+                        return true;
+                    }
+
+                    if ($n instanceof StaticCall
+                        && $n->class instanceof Name
+                        && in_array($n->class->toString(), ['self', 'static'], true)
+                        && $n->name instanceof Identifier
+                        && $n->name->toString() === $name
+                    ) {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                return $n instanceof FuncCall
+                    && $n->name instanceof Name
+                    && $n->name->toString() === $name;
+            }
+        );
+
+        return $found !== null;
+    }
+}

--- a/src/Support/CyclomaticComplexityCalculator.php
+++ b/src/Support/CyclomaticComplexityCalculator.php
@@ -9,9 +9,9 @@ use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\BinaryOp\LogicalAnd;
 use PhpParser\Node\Expr\BinaryOp\LogicalOr;
 use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\Case_;
 use PhpParser\Node\Stmt\Catch_;
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Do_;
 use PhpParser\Node\Stmt\ElseIf_;
 use PhpParser\Node\Stmt\For_;
@@ -22,14 +22,14 @@ use PhpParser\NodeFinder;
 
 class CyclomaticComplexityCalculator
 {
-    public function calculate(ClassMethod $method): int
+    public function calculate(FunctionLike $node): int
     {
         $complexity = 1; // Base complexity for method entry
 
         $nodeFinder = new NodeFinder();
 
         /** @var Node[] $nodes */
-        $nodes = $nodeFinder->find($method->stmts ?? [], function (Node $node): bool {
+        $nodes = $nodeFinder->find($node->getStmts() ?? [], function (Node $node): bool {
             return $node instanceof If_
                 || $node instanceof ElseIf_
                 || $node instanceof While_

--- a/src/Support/CyclomaticComplexityCalculator.php
+++ b/src/Support/CyclomaticComplexityCalculator.php
@@ -24,7 +24,7 @@ class CyclomaticComplexityCalculator
 {
     public function calculate(FunctionLike $node): int
     {
-        $complexity = 1; // Base complexity for method entry
+        $complexity = 1;
 
         $nodeFinder = new NodeFinder();
 

--- a/tests/Rules/CognitiveComplexity/BooleanOperatorSequenceTest.php
+++ b/tests/Rules/CognitiveComplexity/BooleanOperatorSequenceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class BooleanOperatorSequenceTest extends RuleTestCase
+{
+    public function testBooleanRunsAreCountedPerSequence(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/BooleanSequenceClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'singleAndRun', 2, 1),
+                    7,
+                ],
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'mixedRuns', 4, 1),
+                    16,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/low_method_threshold.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/ClassThresholdTest.php
+++ b/tests/Rules/CognitiveComplexity/ClassThresholdTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class ClassThresholdTest extends RuleTestCase
+{
+    public function testClassAggregateExceedsThreshold(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/HighClassTotalClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_CLASS, 'class', 'HighClassTotalClass', 55, 50),
+                    5,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/class_threshold.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/ClosureNestingTest.php
+++ b/tests/Rules/CognitiveComplexity/ClosureNestingTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class ClosureNestingTest extends RuleTestCase
+{
+    public function testClosureRaisesNestingWithoutAddingPoint(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/ClosureNestingClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'build', 2, 1),
+                    7,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/low_method_threshold.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/CustomThresholdTest.php
+++ b/tests/Rules/CognitiveComplexity/CustomThresholdTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class CustomThresholdTest extends RuleTestCase
+{
+    public function testLinearIfsAtCustomThresholdNoError(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/LinearIfsClass.php'], []);
+    }
+
+    public function testNestedIfsExceedsCustomThreshold(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/NestedIfsClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'process', 15, 5),
+                    7,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/custom_threshold.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/DefaultOptionsTest.php
+++ b/tests/Rules/CognitiveComplexity/DefaultOptionsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class DefaultOptionsTest extends RuleTestCase
+{
+    public function testHighlyNestedExceedsDefaultThreshold(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/DeeplyNestedClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'process', 21, 15),
+                    7,
+                ],
+            ]
+        );
+    }
+
+    public function testLinearIfsBelowDefaultThreshold(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/LinearIfsClass.php'], []);
+    }
+
+    public function testNestedFiveDeepAtDefaultThreshold(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/NestedIfsClass.php'], []);
+    }
+
+    public function testShorthandOperatorsAreIgnored(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/IgnoredShorthandClass.php'], []);
+    }
+
+    public function testStandaloneFunctionExceedsDefaultThreshold(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/HighCognitiveFunction.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'function', 'processNested', 21, 15),
+                    6,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/default.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/BooleanSequenceClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/BooleanSequenceClass.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class BooleanSequenceClass
+{
+    public function singleAndRun(bool $a, bool $b, bool $c, bool $d): bool
+    {
+        if ($a && $b && $c && $d) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function mixedRuns(bool $a, bool $b, bool $c, bool $d): bool
+    {
+        if ($a && $b || $c && $d) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/ClosureNestingClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/ClosureNestingClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class ClosureNestingClass
+{
+    public function build(): callable
+    {
+        return function (int $x): int {
+            if ($x > 0) {
+                return $x * 2;
+            }
+
+            return 0;
+        };
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/DeeplyNestedClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/DeeplyNestedClass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class DeeplyNestedClass
+{
+    public function process(int $a, int $b, int $c, int $d, int $e, int $f): void
+    {
+        if ($a > 0) {
+            if ($b > 0) {
+                if ($c > 0) {
+                    if ($d > 0) {
+                        if ($e > 0) {
+                            if ($f > 0) {
+                                echo 'all';
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/GotoClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/GotoClass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class GotoClass
+{
+    public function jump(int $x): int
+    {
+        if ($x > 0) {
+            goto end;
+        }
+
+        end:
+        return 0;
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/Helper.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/Helper.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class Helper
+{
+    public function method(): string
+    {
+        return 'helper';
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/HighClassTotalClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/HighClassTotalClass.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class HighClassTotalClass
+{
+    public function method1(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+
+    public function method2(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+
+    public function method3(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+
+    public function method4(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+
+    public function method5(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+
+    public function method6(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+
+    public function method7(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+
+    public function method8(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+
+    public function method9(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+
+    public function method10(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+
+    public function method11(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/HighCognitiveFunction.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/HighCognitiveFunction.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+// Cognitive complexity = 1+2+3+4+5+6 = 21
+function processNested(int $a, int $b, int $c, int $d, int $e, int $f): void
+{
+    if ($a > 0) {
+        if ($b > 0) {
+            if ($c > 0) {
+                if ($d > 0) {
+                    if ($e > 0) {
+                        if ($f > 0) {
+                            echo 'all';
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/IgnorePatternFixtureClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/IgnorePatternFixtureClass.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class IgnorePatternFixtureClass
+{
+    public function ignoredComplexMethod(int $a, int $b, int $c, int $d, int $e, int $f): void
+    {
+        if ($a > 0) {
+            if ($b > 0) {
+                if ($c > 0) {
+                    if ($d > 0) {
+                        if ($e > 0) {
+                            if ($f > 0) {
+                                echo 'all';
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public function reportedComplexMethod(int $a, int $b, int $c, int $d, int $e, int $f): void
+    {
+        if ($a > 0) {
+            if ($b > 0) {
+                if ($c > 0) {
+                    if ($d > 0) {
+                        if ($e > 0) {
+                            if ($f > 0) {
+                                echo 'all';
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/IgnoredShorthandClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/IgnoredShorthandClass.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class IgnoredShorthandClass
+{
+    public function process(?string $a, ?Helper $obj): string
+    {
+        $value = $a ?? 'default';
+        $result = $obj?->method() ?? 'fallback';
+        $a ??= 'init';
+
+        return $value . $result;
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/LinearIfsClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/LinearIfsClass.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class LinearIfsClass
+{
+    public function process(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            echo 'a';
+        }
+
+        if ($b > 0) {
+            echo 'b';
+        }
+
+        if ($c > 0) {
+            echo 'c';
+        }
+
+        if ($d > 0) {
+            echo 'd';
+        }
+
+        if ($e > 0) {
+            echo 'e';
+        }
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/MatchClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/MatchClass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class MatchClass
+{
+    public function getStatus(int $code): string
+    {
+        return match ($code) {
+            200 => 'OK',
+            404 => 'Not Found',
+            500 => 'Error',
+            default => 'Unknown',
+        };
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/MultiLevelBreakClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/MultiLevelBreakClass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class MultiLevelBreakClass
+{
+    /**
+     * @param array<array<int|null>> $groups
+     */
+    public function search(array $groups): void
+    {
+        foreach ($groups as $group) {
+            foreach ($group as $item) {
+                if ($item === null) {
+                    break 2;
+                }
+            }
+        }
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/NestedIfsClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/NestedIfsClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class NestedIfsClass
+{
+    public function process(int $a, int $b, int $c, int $d, int $e): void
+    {
+        if ($a > 0) {
+            if ($b > 0) {
+                if ($c > 0) {
+                    if ($d > 0) {
+                        if ($e > 0) {
+                            echo 'all';
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/RecursionClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/RecursionClass.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class RecursionClass
+{
+    public function factorial(int $n): int
+    {
+        if ($n <= 1) {
+            return 1;
+        }
+
+        return $n * $this->factorial($n - 1);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/SwitchClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/SwitchClass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+class SwitchClass
+{
+    public function topLevel(int $x): string
+    {
+        switch ($x) {
+            case 1: return 'a';
+            case 2: return 'b';
+
+            default: return 'c';
+        }
+    }
+
+    public function nested(int $x, int $y): string
+    {
+        if ($x > 0) {
+            switch ($y) {
+                case 1: return 'a';
+                case 2: return 'b';
+
+                default: return 'c';
+            }
+        }
+
+        return 'fallback';
+    }
+}

--- a/tests/Rules/CognitiveComplexity/Fixture/TryCatchFinallyClass.php
+++ b/tests/Rules/CognitiveComplexity/Fixture/TryCatchFinallyClass.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity\Fixture;
+
+use LogicException;
+use RuntimeException;
+
+class TryCatchFinallyClass
+{
+    public function run(int $x, int $y, int $z): void
+    {
+        try {
+            if ($x > 0) {
+                throw new RuntimeException();
+            }
+        } catch (RuntimeException $e) {
+            // empty
+        } catch (LogicException $e) {
+            if ($y > 0) {
+                $this->handle();
+            }
+        } finally {
+            if ($z > 0) {
+                $this->log();
+            }
+        }
+    }
+
+    protected function handle(): void {}
+
+    protected function log(): void {}
+}

--- a/tests/Rules/CognitiveComplexity/GotoTest.php
+++ b/tests/Rules/CognitiveComplexity/GotoTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class GotoTest extends RuleTestCase
+{
+    public function testGotoAddsIncrement(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/GotoClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'jump', 2, 1),
+                    7,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/low_method_threshold.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/IgnorePatternTest.php
+++ b/tests/Rules/CognitiveComplexity/IgnorePatternTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class IgnorePatternTest extends RuleTestCase
+{
+    public function testIgnoredMethodSkipped(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/IgnorePatternFixtureClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'reportedComplexMethod', 21, 5),
+                    24,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/ignore_pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/InvalidPatternTest.php
+++ b/tests/Rules/CognitiveComplexity/InvalidPatternTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use InvalidArgumentException;
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class InvalidPatternTest extends RuleTestCase
+{
+    public function testInvalidPattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid regex pattern in ignore_pattern configuration');
+
+        $this->analyse([
+            __DIR__ . '/Fixture/LinearIfsClass.php',
+        ], []);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/invalid_pattern.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/MatchExpressionTest.php
+++ b/tests/Rules/CognitiveComplexity/MatchExpressionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class MatchExpressionTest extends RuleTestCase
+{
+    public function testMatchExpressionAddsSingleIncrement(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/MatchClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'getStatus', 1, 0),
+                    7,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/match_expression.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/MultiLevelBreakTest.php
+++ b/tests/Rules/CognitiveComplexity/MultiLevelBreakTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class MultiLevelBreakTest extends RuleTestCase
+{
+    public function testMultiLevelBreakAddsIncrement(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/MultiLevelBreakClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'search', 7, 1),
+                    10,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/low_method_threshold.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/NestingPenaltyTest.php
+++ b/tests/Rules/CognitiveComplexity/NestingPenaltyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class NestingPenaltyTest extends RuleTestCase
+{
+    public function testFiveLinearIfsScoreFive(): void
+    {
+        $this->analyse([__DIR__ . '/Fixture/LinearIfsClass.php'], []);
+    }
+
+    public function testFiveNestedIfsScoreFifteen(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/NestedIfsClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'process', 15, 6),
+                    7,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/nesting_penalty.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/RecursionTest.php
+++ b/tests/Rules/CognitiveComplexity/RecursionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class RecursionTest extends RuleTestCase
+{
+    public function testDirectRecursionAddsIncrement(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/RecursionClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'factorial', 2, 1),
+                    7,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/low_method_threshold.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/SwitchExpressionTest.php
+++ b/tests/Rules/CognitiveComplexity/SwitchExpressionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class SwitchExpressionTest extends RuleTestCase
+{
+    public function testSwitchAddsStructuralIncrementWithNesting(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/SwitchClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'topLevel', 1, 0),
+                    7,
+                ],
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'nested', 3, 0),
+                    17,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/match_expression.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/TryCatchFinallyTest.php
+++ b/tests/Rules/CognitiveComplexity/TryCatchFinallyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CognitiveComplexity;
+
+use Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CognitiveComplexityRule>
+ */
+class TryCatchFinallyTest extends RuleTestCase
+{
+    public function testTryCatchFinallyScoring(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Fixture/TryCatchFinallyClass.php'],
+            [
+                [
+                    sprintf(CognitiveComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'method', 'run', 6, 0),
+                    10,
+                ],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/match_expression.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CognitiveComplexityRule::class);
+    }
+}

--- a/tests/Rules/CognitiveComplexity/config/class_threshold.neon
+++ b/tests/Rules/CognitiveComplexity/config/class_threshold.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule
+
+parameters:
+    meliorstan:
+        cognitive_complexity:
+            method_maximum: 15
+            class_maximum: 50

--- a/tests/Rules/CognitiveComplexity/config/custom_threshold.neon
+++ b/tests/Rules/CognitiveComplexity/config/custom_threshold.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule
+
+parameters:
+    meliorstan:
+        cognitive_complexity:
+            method_maximum: 5

--- a/tests/Rules/CognitiveComplexity/config/default.neon
+++ b/tests/Rules/CognitiveComplexity/config/default.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule

--- a/tests/Rules/CognitiveComplexity/config/ignore_pattern.neon
+++ b/tests/Rules/CognitiveComplexity/config/ignore_pattern.neon
@@ -1,0 +1,11 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule
+
+parameters:
+    meliorstan:
+        cognitive_complexity:
+            method_maximum: 5
+            ignore_pattern: '^ignored'

--- a/tests/Rules/CognitiveComplexity/config/invalid_pattern.neon
+++ b/tests/Rules/CognitiveComplexity/config/invalid_pattern.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule
+
+parameters:
+    meliorstan:
+        cognitive_complexity:
+            ignore_pattern: '[invalid'

--- a/tests/Rules/CognitiveComplexity/config/low_method_threshold.neon
+++ b/tests/Rules/CognitiveComplexity/config/low_method_threshold.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule
+
+parameters:
+    meliorstan:
+        cognitive_complexity:
+            method_maximum: 1

--- a/tests/Rules/CognitiveComplexity/config/match_expression.neon
+++ b/tests/Rules/CognitiveComplexity/config/match_expression.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule
+
+parameters:
+    meliorstan:
+        cognitive_complexity:
+            method_maximum: 0

--- a/tests/Rules/CognitiveComplexity/config/nesting_penalty.neon
+++ b/tests/Rules/CognitiveComplexity/config/nesting_penalty.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/extension.neon
+
+rules:
+    - Orrison\MeliorStan\Rules\CognitiveComplexity\CognitiveComplexityRule
+
+parameters:
+    meliorstan:
+        cognitive_complexity:
+            method_maximum: 6

--- a/tests/Rules/CyclomaticComplexity/CyclomaticComplexityRuleTest.php
+++ b/tests/Rules/CyclomaticComplexity/CyclomaticComplexityRuleTest.php
@@ -20,6 +20,7 @@ class CyclomaticComplexityRuleTest extends RuleTestCase
                 __DIR__ . '/Fixture/VeryHighAverageComplexity.php',
                 __DIR__ . '/Fixture/HighComplexityTrait.php',
                 __DIR__ . '/Fixture/CatchAndLogicalOperators.php',
+                __DIR__ . '/Fixture/HighComplexityFunction.php',
             ],
             [
                 // HighComplexityClass::methodWithComplexityEleven (complexity 11)
@@ -60,6 +61,11 @@ class CyclomaticComplexityRuleTest extends RuleTestCase
                 // HighComplexityTrait class average (11.00)
                 [
                     sprintf(CyclomaticComplexityRule::ERROR_MESSAGE_TEMPLATE_CLASS, 'trait', 'HighComplexityTrait', 11.00, 10),
+                    6,
+                ],
+                // Standalone function processWithComplexityEleven (complexity 11)
+                [
+                    sprintf(CyclomaticComplexityRule::ERROR_MESSAGE_TEMPLATE_METHOD, 'function', 'processWithComplexityEleven', 11, 10),
                     6,
                 ],
             ]

--- a/tests/Rules/CyclomaticComplexity/Fixture/HighComplexityFunction.php
+++ b/tests/Rules/CyclomaticComplexity/Fixture/HighComplexityFunction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Orrison\MeliorStan\Tests\Rules\CyclomaticComplexity\Fixture;
+
+// Complexity: 11 (exceeds default threshold of 10)
+function processWithComplexityEleven(int $a): void
+{
+    if ($a > 0) {          // 1
+        if ($a > 10) {      // 2
+            echo 'large';
+        } elseif ($a > 5) { // 3
+            echo 'medium';
+        }
+    } elseif ($a < 0) {    // 4
+        while ($a < 0) {   // 5
+            $a++;
+        }
+    }
+
+    for ($i = 0; $i < 3; $i++) { // 6
+        echo $i;
+    }
+
+    foreach ([1, 2] as $v) { // 7
+        echo $v;
+    }
+
+    $x = $a > 0 ? 'yes' : 'no'; // 8
+
+    $y = $a ?? 0; // 9
+
+    if ($a === 100) { // 10
+        echo 'exact';
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Cognitive Complexity rule to the codebase, allowing detection and configuration of cognitive complexity thresholds for methods, functions, and classes. It also improves the documentation and configuration for complexity-related rules, clarifies the scope of the Cyclomatic Complexity rule, and adds cross-references between related rules. The most important changes are grouped below:

**New Cognitive Complexity Rule:**

* Added a new `CognitiveComplexityRule` (`src/Rules/CognitiveComplexity/CognitiveComplexityRule.php`) that checks cognitive complexity for methods, functions, and classes, with configurable thresholds and an ignore pattern.
* Introduced a configuration class for the new rule (`src/Rules/CognitiveComplexity/Config.php`).
* Registered the new rule and its calculator in the service configuration (`config/extension.neon`). [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R438) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R449-R454)
* Added default and schema configuration for cognitive complexity thresholds and ignore patterns (`config/extension.neon`). [[1]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R144-R148) [[2]](diffhunk://#diff-0174414c4a7d69de966ebd24c1b82456a83f4debfac8ad808639494fdeb39cc4R264-R267)
* Created comprehensive documentation for the new rule, including configuration, usage, and examples (`docs/CognitiveComplexity.md`).
* Updated the main rule listing in the `README.md` to include the new Cognitive Complexity rule and clarified the description of Cyclomatic Complexity.

**Cyclomatic Complexity Rule Improvements:**

* Updated the Cyclomatic Complexity rule to clarify that it applies to both methods and standalone functions, and improved documentation to distinguish between class- and function-level reporting. [[1]](diffhunk://#diff-033351ea9fe80e82fb781d146179595f732389512d8a742ccc5be6b4e0397fc7L20-R30) [[2]](diffhunk://#diff-033351ea9fe80e82fb781d146179595f732389512d8a742ccc5be6b4e0397fc7L185-R203)
* Minor code update to ensure `Function_` nodes are imported for standalone function support.

**Documentation Enhancements and Cross-References:**

* Added "Related Rules" sections to the documentation for Cyclomatic Complexity and Excessive Class Complexity, explaining how the new Cognitive Complexity rule complements existing checks. [[1]](diffhunk://#diff-0d7148490cbb0e3a1cea3f6126f70c9d6d61ea83183fcd0f10fd2b0115c40f28R157-R168) [[2]](diffhunk://#diff-033351ea9fe80e82fb781d146179595f732389512d8a742ccc5be6b4e0397fc7L185-R203)
* Clarified in the documentation how each rule's metric works and when to use each for class-level complexity analysis. [[1]](diffhunk://#diff-0d7148490cbb0e3a1cea3f6126f70c9d6d61ea83183fcd0f10fd2b0115c40f28R157-R168) [[2]](diffhunk://#diff-033351ea9fe80e82fb781d146179595f732389512d8a742ccc5be6b4e0397fc7L185-R203) [[3]](diffhunk://#diff-5fa9bbb5e3364237f5d72ec555f1f67e1cf64642663fcdfa147b5f1d02f7438aR1-R181)

These changes provide a more comprehensive and configurable approach to code complexity analysis, making it easier to enforce code quality standards and understandability across the codebase.

Closes https://github.com/Orrison/MeliorStan/issues/63